### PR TITLE
Fix status update when not using versioning

### DIFF
--- a/pkg/codegen/templates/server/handlers.go.tmpl
+++ b/pkg/codegen/templates/server/handlers.go.tmpl
@@ -355,7 +355,6 @@ func Update{{.Name}}Status(w http.ResponseWriter, r *http.Request) {
 	{{- if .Tags }}{{- if eq (index .Tags "versioning") "enabled" }}
 	// Preserve server-managed version field in status
 	prevVersion := res.Status.Version
-	res.Status = statusUpdate
 	res.Status.Version = prevVersion
 	{{- end }}{{- end }}
 	res.Touch()


### PR DESCRIPTION
### Description

Shane was running through the tutorial and noticed it didn't work on the latest version of Fabrica (status wasn't being updated). Looking at the code, it looks like the status update was not being generated at all due to a new conditional, so I've just pulled the status update (duplicate code) out to ensure it always happens.

Before (gets a 200 response, doesn't update status):
```bash
$ curl -X PUT http://localhost:8080/devices/dev-4dd8a9a5/status \
  -H "Content-Type: application/json" \
  -d '{
    "deviceType": "Node",
    "manufacturer": "HPE",
    "partNumber": "SYS-1234",
    "serialNumber": "SN-ABC123",
    "properties": {
      "bios_boot_mode": "uefi",
      "dns_domain": "cluster.local"
    }
  }'
{"apiVersion":"v1","kind":"Device","schemaVersion":"v1","metadata":{"name":"compute-node-01","uid":"dev-4dd8a9a5","labels":{"rack":"r10","role":"compute"},"createdAt":"2025-11-05T09:14:55.315449-08:00","updatedAt":"2025-11-05T09:17:27.327804-08:00"},"spec":{},"status":{}}
```

After:
```bash
$ curl -X PUT http://localhost:8080/devices/dev-4dd8a9a5/status \
  -H "Content-Type: application/json" \
  -d '{
    "deviceType": "Node",
    "manufacturer": "HPE",
    "partNumber": "SYS-1234",
    "serialNumber": "SN-ABC123",
    "properties": {
      "bios_boot_mode": "uefi",
      "dns_domain": "cluster.local"
    }
  }'
{"apiVersion":"v1","kind":"Device","schemaVersion":"v1","metadata":{"name":"compute-node-01","uid":"dev-4dd8a9a5","labels":{"rack":"r10","role":"compute"},"createdAt":"2025-11-05T09:14:55.315449-08:00","updatedAt":"2025-11-05T09:20:29.671248-08:00"},"spec":{},"status":{"deviceType":"Node","manufacturer":"HPE","partNumber":"SYS-1234","serialNumber":"SN-ABC123","properties":{"bios_boot_mode":"uefi","dns_domain":"cluster.local"}}}
```

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
