### PR TITLE
chore: do not omit YAML in gitignore template

### DIFF
--- a/pkg/codegen/templates/init/gitignore.tmpl
+++ b/pkg/codegen/templates/init/gitignore.tmpl
@@ -28,12 +28,6 @@ go.work
 data/
 *.db
 
-# Config files (may contain secrets)
-*.yaml
-*.yml
-!example.yaml
-!example.yml
-
 # IDE files
 .vscode/
 .idea/


### PR DESCRIPTION
Quick fix for some generated gitignore rules that aren't relevant to Fabrica, and exclude files that really should be included in Fabrica projects' committed files.

Also unsure if we need the skips for Windows binaries and C libraries, but ignoring thos is more benign than omitting type/version config. You _shouldn't_ get .exes or .sos in Fabrica generated code, but they shouldn't be committed either.