### PR TITLE
Fix fabrica init path to work with agentic tools

### DIFF
--- a/cmd/fabrica/init.go
+++ b/cmd/fabrica/init.go
@@ -25,6 +25,7 @@ type initOptions struct {
 	interactive bool
 	modulePath  string
 	description string
+	workDir     string // Target directory for project creation
 
 	// Feature flags instead of modes
 	withAuth    bool // Enable authentication
@@ -110,6 +111,15 @@ You can initialize in an existing directory by using '.' as the project name,
 or by providing the name of an existing directory.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if opts.workDir != "" {
+				if err := os.MkdirAll(opts.workDir, 0755); err != nil {
+					return fmt.Errorf("failed to create working directory: %w", err)
+				}
+				if err := os.Chdir(opts.workDir); err != nil {
+					return fmt.Errorf("failed to change directory to %s: %w", opts.workDir, err)
+				}
+			}
+
 			projectName := "myproject"
 			if len(args) > 0 {
 				projectName = args[0]
@@ -137,6 +147,7 @@ or by providing the name of an existing directory.`,
 	cmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", false, "Interactive wizard mode")
 	cmd.Flags().StringVar(&opts.modulePath, "module", "", "Go module path (e.g., github.com/user/project)")
 	cmd.Flags().StringVar(&opts.description, "description", "", "Project description")
+	cmd.Flags().StringVarP(&opts.workDir, "dir", "d", "", "Target working directory (useful for automation/MCP)")
 
 	// Feature flags
 	cmd.Flags().BoolVar(&opts.withAuth, "auth", false, "Enable authentication with TokenSmith")
@@ -325,7 +336,7 @@ func runInit(projectName string, opts *initOptions) error {
 			// Create new directory
 			fmt.Printf("🚀 Creating %s project...\n", projectName)
 		}
-		projectBaseName = projectName
+		projectBaseName = filepath.Base(projectName)
 		targetDir = projectName
 	}
 


### PR DESCRIPTION
Working with cline and a Fabrica MCP server, the old Fabrica init was causing errors like:
```
Error (1): Error: failed to create project structure: mkdir cline_test: read-only file system Usage: fabrica init [
```
And this is because of how the Cline subprocess agents work, which are in a sandbox environment. With this fix, we are able to get it working successfully:
```
Successfully initialized Fabrica project 'cline_test' in your workspace directory. The project structure includes:

- `.fabrica.yaml` - Fabrica configuration
- `apis.yaml` - API group definition (example.fabrica.dev, storage v1)
- `go.mod` - Go module file
- `cmd/server/main.go` - Server entry point
- `apis/example.fabrica.dev/v1/` - API types directory
- `internal/storage/` - Storage layer
- `.env.template` - Environment variables template

Next steps to continue development:
1. Define resource types in `apis/example.fabrica.dev/v1/*_types.go`
2. Run `fabrica add resource <name>` to add resources
3. Run `fabrica generate` to generate code
4. Run `go mod tidy` to update dependencies
5. Start server with `go run ./cmd/server/`
```

This is with the MCP server available at: https://github.com/bmcdonald3/fabrica-mcp
And configured in cline like this:
```
{
  "mcpServers": {
    "fabrica": {
      "command": "uv",
      "args": [
        "--directory",
        "/Users/ben.mcdonald/fabrica-mcp",
        "run",
        "fabrica-mcp"
      ]
    }
  }
}
```