### PR TITLE
chore: update version information to v0.4.4 in documentation and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,7 +287,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storage system architecture documentation
 - Getting started guide
 
-[Unreleased]: https://github.com/openchami/fabrica/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/openchami/fabrica/compare/v0.4.4...HEAD
+[v0.4.4]: https://github.com/openchami/fabrica/compare/v0.4.3...v0.4.4
+[v0.4.3]: https://github.com/openchami/fabrica/compare/v0.4.2...v0.4.3
+[v0.4.2]: https://github.com/openchami/fabrica/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/openchami/fabrica/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/openchami/fabrica/compare/v0.3.1...v0.4.0
 [v0.3.1]: https://github.com/openchami/fabrica/compare/v0.2.9...v0.3.1

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
-LATEST_RELEASE ?= v0.4.1
+LATEST_RELEASE ?= v0.4.4
 ACT_GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod | cut -d. -f1,2)
 ACT_LOCAL_GO_VERSION ?= 1.25
 ACT_DOCKER_HOST ?= $(shell docker context inspect $${DOCKER_CONTEXT:-$$(docker context show 2>/dev/null)} 2>/dev/null | awk -F'"' '/"Host":/ {print $$4; exit}')

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Fabrica is a powerful code generation tool that accelerates API development by t
 
 ## 📦 Installation
 
-### Latest Release (v0.4.1)
+### Latest Release (v0.4.4)
 
 **macOS/Linux:**
 ```bash
 # Direct download and install
-curl -L https://github.com/openchami/fabrica/releases/download/v0.4.1/fabrica-$(uname -s)-$(uname -m) -o fabrica
+curl -L https://github.com/openchami/fabrica/releases/download/v0.4.4/fabrica-$(uname -s)-$(uname -m) -o fabrica
 chmod +x fabrica
 sudo mv fabrica /usr/local/bin/
 
@@ -70,7 +70,7 @@ fabrica version
 
 **Using Go:**
 ```bash
-go install github.com/openchami/fabrica/cmd/fabrica@v0.4.1
+go install github.com/openchami/fabrica/cmd/fabrica@v0.4.4
 ```
 
 ### Development Version
@@ -342,7 +342,7 @@ We welcome contributions from the community! Here's how to get involved:
 
 ## 🏷️ Releases & Roadmap
 
-**Current Version:** [v0.4.1](https://github.com/openchami/fabrica/releases/tag/v0.4.1)
+**Current Version:** [v0.4.4](https://github.com/openchami/fabrica/releases/tag/v0.4.4)
 
 **📅 Recent Updates:**
 - ✅ Hub/Spoke API versioning with automatic conversion

--- a/USAGE.md
+++ b/USAGE.md
@@ -28,7 +28,9 @@ fabrica version
 
 **Expected output:**
 ```
-Fabrica v0.4.1
+Fabrica version v0.4.4
+  commit: <git-sha>
+  built: <timestamp>
 ```
 
 If you get "command not found", see [Installation](README.md#-installation).

--- a/cmd/fabrica/main.go
+++ b/cmd/fabrica/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 
@@ -21,7 +22,50 @@ var (
 	date    = "unknown"
 )
 
+func resolveVersionInfo(currentVersion, currentCommit, currentDate string, buildInfo *debug.BuildInfo) (string, string, string) {
+	if buildInfo == nil {
+		return currentVersion, currentCommit, currentDate
+	}
+
+	resolvedVersion := currentVersion
+	resolvedCommit := currentCommit
+	resolvedDate := currentDate
+
+	if resolvedVersion == "dev" && buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
+		resolvedVersion = buildInfo.Main.Version
+	}
+
+	if resolvedCommit != "none" && resolvedDate != "unknown" {
+		return resolvedVersion, resolvedCommit, resolvedDate
+	}
+
+	for _, setting := range buildInfo.Settings {
+		if resolvedCommit == "none" && setting.Key == "vcs.revision" && setting.Value != "" {
+			resolvedCommit = setting.Value
+		}
+		if resolvedDate == "unknown" && setting.Key == "vcs.time" && setting.Value != "" {
+			resolvedDate = setting.Value
+		}
+	}
+
+	return resolvedVersion, resolvedCommit, resolvedDate
+}
+
+func resolveBuildVersionInfo() {
+	if version != "dev" && commit != "none" && date != "unknown" {
+		return
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	version, commit, date = resolveVersionInfo(version, commit, date, buildInfo)
+}
+
 func main() {
+	resolveBuildVersionInfo()
 	mcp.Version = version
 
 	rootCmd := &cobra.Command{

--- a/cmd/fabrica/main_version_test.go
+++ b/cmd/fabrica/main_version_test.go
@@ -1,0 +1,72 @@
+// Copyright © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersionInfo_UsesModuleVersionWhenUnset(t *testing.T) {
+	bi := &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.4.3"},
+	}
+
+	resolvedVersion, resolvedCommit, resolvedDate := resolveVersionInfo("dev", "none", "unknown", bi)
+
+	if resolvedVersion != "v0.4.3" {
+		t.Fatalf("expected version v0.4.3, got %q", resolvedVersion)
+	}
+	if resolvedCommit != "none" {
+		t.Fatalf("expected commit none when unavailable, got %q", resolvedCommit)
+	}
+	if resolvedDate != "unknown" {
+		t.Fatalf("expected date unknown when unavailable, got %q", resolvedDate)
+	}
+}
+
+func TestResolveVersionInfo_UsesVCSSettingsWhenUnset(t *testing.T) {
+	bi := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abc123"},
+			{Key: "vcs.time", Value: "2026-05-07T12:00:00Z"},
+		},
+	}
+
+	resolvedVersion, resolvedCommit, resolvedDate := resolveVersionInfo("dev", "none", "unknown", bi)
+
+	if resolvedVersion != "dev" {
+		t.Fatalf("expected version to remain dev for devel builds, got %q", resolvedVersion)
+	}
+	if resolvedCommit != "abc123" {
+		t.Fatalf("expected commit abc123, got %q", resolvedCommit)
+	}
+	if resolvedDate != "2026-05-07T12:00:00Z" {
+		t.Fatalf("expected vcs time to be used, got %q", resolvedDate)
+	}
+}
+
+func TestResolveVersionInfo_PreservesLdflagsValues(t *testing.T) {
+	bi := &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.4.3"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "frombuildinfo"},
+			{Key: "vcs.time", Value: "frombuildinfo"},
+		},
+	}
+
+	resolvedVersion, resolvedCommit, resolvedDate := resolveVersionInfo("v9.9.9", "ldflagscommit", "ldflagsdate", bi)
+
+	if resolvedVersion != "v9.9.9" {
+		t.Fatalf("expected ldflags version to be preserved, got %q", resolvedVersion)
+	}
+	if resolvedCommit != "ldflagscommit" {
+		t.Fatalf("expected ldflags commit to be preserved, got %q", resolvedCommit)
+	}
+	if resolvedDate != "ldflagsdate" {
+		t.Fatalf("expected ldflags date to be preserved, got %q", resolvedDate)
+	}
+}

--- a/docs/_posts/2025-11-04-basic-crud.md
+++ b/docs/_posts/2025-11-04-basic-crud.md
@@ -11,7 +11,7 @@ description: "How the CLI and Go library help you use your API the same way ever
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 APIs are easier to use when the client is predictable. You should not have to remember custom flags or one‑off scripts. Fabrica generates two clients that match your server: a CLI and a Go library. They share patterns and types, so your shell steps and your code read the same way.
 

--- a/docs/_posts/2025-11-04-cloud-events.md
+++ b/docs/_posts/2025-11-04-cloud-events.md
@@ -11,7 +11,7 @@ description: "How Fabrica’s event system lets you model and drive resource sta
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 Events let your API tell the world what changed. In Fabrica, that stream becomes more than a log. It is a simple way to model a resource’s state and move it forward. When a resource is created, updated, or deleted, the server publishes an event. When Status changes in a meaningful way, you can publish a condition change. Other parts of your system can subscribe and react.
 

--- a/docs/_posts/2025-11-04-pluggable-storage.md
+++ b/docs/_posts/2025-11-04-pluggable-storage.md
@@ -11,7 +11,7 @@ description: "How the storage contract lets you swap file and database backends 
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 Fabrica generates REST services from Kubernetes‑style resources. The shape is always the same: APIVersion, Kind, Metadata, Spec, and Status. Handlers, routes, models, and the client are generated from templates. What you store those resources in is up to you. The storage layer is pluggable, so you can start with files and move to a database later without rewriting your API.
 

--- a/docs/_posts/2025-11-04-rack-reconciliation.md
+++ b/docs/_posts/2025-11-04-rack-reconciliation.md
@@ -11,7 +11,7 @@ description: "A gentle look at controllers that react to change and keep resourc
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 Some jobs are better done by the system than by users clicking through steps. Reconciliation makes this possible. You declare what you want in Spec, and a controller reads that intent and works until the resource reaches a steady state. When things drift, the controller nudges them back.
 

--- a/docs/_posts/2025-11-04-spec-version-history.md
+++ b/docs/_posts/2025-11-04-spec-version-history.md
@@ -11,11 +11,11 @@ description: "How updating Fabrica and regenerating code lets you grow existing 
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 APIs live for a long time. They grow as your product grows. The hard part is adding features without breaking what you already shipped. Fabrica is built for this kind of steady change. You keep your resource definitions as the source of truth. The generator keeps the rest in sync.
 
-Here is how it works in practice. Update Fabrica to v0.4.1 (or any release v0.3.1 and newer). v0.3.1 added opt‑in spec version history. Take a service you built earlier, add the versioning marker to one resource, and run the generator again. The server, storage helpers, client library, and CLI pick up version endpoints and commands. Your custom code stays where it is.
+Here is how it works in practice. Update Fabrica to v0.4.4 (or any release v0.3.1 and newer). v0.3.1 added opt-in spec version history. Take a service you built earlier, add the versioning marker to one resource, and run the generator again. The server, storage helpers, client library, and CLI pick up version endpoints and commands. Your custom code stays where it is.
 
 Under the hood, the CLI flag `--with-versioning` in `cmd/fabrica/add.go` emits a resource marker. The generator tags that resource (`pkg/codegen/generator.go`). Templates extend storage and handlers: snapshots and helpers come from `pkg/codegen/templates/storage/file.go.tmpl`; handlers that set `status.version` live in `pkg/codegen/templates/server/handlers.go.tmpl`. Client methods and CLI subcommands come from `pkg/codegen/templates/client/client.go.tmpl` and `client/cmd.go.tmpl`.
 

--- a/docs/_posts/2025-11-04-status-subresource.md
+++ b/docs/_posts/2025-11-04-status-subresource.md
@@ -11,7 +11,7 @@ description: "Why encoding REST rules in generators leads to steadier, more supp
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 Many API teams say they follow REST, but each team writes it a little differently. Over time, small differences pile up. One service wraps list results in an object, another returns an array. One updates status together with spec, another splits them. These choices matter to users, and they matter even more when you have to support the API for years.
 

--- a/docs/_posts/2025-11-04-welcome-to-fabrica.md
+++ b/docs/_posts/2025-11-04-welcome-to-fabrica.md
@@ -11,7 +11,7 @@ description: "A tour of the server you get from Fabrica and how it helps you shi
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.1):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
 
 ## Context
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -26,7 +26,7 @@ Verify installation:
 
 ```bash
 fabrica --version
-# Output: fabrica version v0.4.1
+# Output: fabrica version v0.4.4
 ```
 
 ## Create Your First API

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -52,7 +52,7 @@ Verify installation:
 
 ```bash
 fabrica --version
-# Output: fabrica version v0.4.1
+# Output: fabrica version v0.4.4
 ```
 
 ## Step 1: Initialize Your Project

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -402,7 +402,7 @@ fabrica version
 
 **Output:**
 ```
-Fabrica version v0.4.1
+Fabrica version v0.4.4
   commit: abc123def456
   built: 2025-01-14T10:00:00Z
 ```

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -212,7 +212,7 @@ Before tagging a release, ensure the following readiness criteria are met:
 
 - [ ] **Previous version → current version upgrade** is tested:
   - Generate project with previous Fabrica version (e.g., v0.3.1)
-  - Run `fabrica generate` with current CLI version (v0.4.1)
+  - Run `fabrica generate` with current CLI version (v0.4.4)
   - Verify generated code compiles and basic operations work
 
 ### Binary Smoke Testing


### PR DESCRIPTION
### Description

This pull request updates Fabrica to version v0.4.4, updating all documentation, references, and versioning logic throughout the project. In addition, it improves the way the CLI resolves and displays version information by enhancing build metadata handling and adds tests for this logic.

**Version bump and documentation updates:**

* Updated all references to the latest release from v0.4.1 to v0.4.4 across documentation files, installation instructions, guides, and blog posts. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL290-R293) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L16-R16) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L345-R345) [[6]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dL31-R33) [[7]](diffhunk://#diff-198ff046f82f78faa515d0ececa3fdb5c756de19256d2ae9f20151ee7b2c2113L14-R14) [[8]](diffhunk://#diff-32c9c73897d6d2a793100852e6cab95d6477d195ef2e378457c61b22de44928fL14-R14) [[9]](diffhunk://#diff-c47b83576d7d462db6aa1339d85c51e50831fef709242b68d751d9c0265fe6cbL14-R14) [[10]](diffhunk://#diff-2949c1696e6f46ea702c86d68da1faf81b7a02d79146a57889cd04a60cf96235L14-R14) [[11]](diffhunk://#diff-3dd55e9517212085fd0f80201395caa49326e0196d62c807ceb0660a76adb121L14-R18) [[12]](diffhunk://#diff-ce0b9d63d7b9dca3c15df05598446ad283dd40655c0efaba66f5bea22791b398L14-R14) [[13]](diffhunk://#diff-121af133a5c761a284b46d2a06b3441b275f08de6764b470b4937067b023fcf0L14-R14) [[14]](diffhunk://#diff-cfabf1cf40f1208bf2a9e4198f0fa64a0fb3de07c1e2a005a3965e1a699a9e37L29-R29) [[15]](diffhunk://#diff-0a519ea24788b99a6c19c0f020778ab292d7da07c6a65689a753833cec2346a0L55-R55) [[16]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L405-R405) [[17]](diffhunk://#diff-85e1bc53647f7e90e5fe6da705623a2fe9be002bc165644ee04ce683525ce887L215-R215)

**CLI version reporting improvements:**

* Enhanced the CLI's version reporting by adding logic in `cmd/fabrica/main.go` to resolve version, commit, and build date from Go build metadata (`debug.BuildInfo`), falling back to ldflags or module info as appropriate. [[1]](diffhunk://#diff-98d4fdcb45982bb50e348c08f4041a510d6b3543a40ab1dd642e53c4b492a7beR12) [[2]](diffhunk://#diff-98d4fdcb45982bb50e348c08f4041a510d6b3543a40ab1dd642e53c4b492a7beR25-R68)
* Updated the version output format in documentation and usage examples to reflect the new, more detailed version information. [[1]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dL31-R33) [[2]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L405-R405)

**Testing:**

* Added a new test file `cmd/fabrica/main_version_test.go` to verify the version resolution logic, ensuring correct behavior for various build scenarios (module version, VCS settings, ldflags overrides).

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [X] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [X] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
