### PR TITLE
chore: update documentation and examples for v0.4.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.4.5] - 2026-05-12
+
+### Added
+- Generated servers now expose a health check endpoint, and generated clients/CLI gain a matching health command for service status checks.
+- Added regression coverage for health endpoint OpenAPI parity, version parsing, and generation compatibility checks.
+
+### Changed
+- Improved version reporting so release builds, git-describe builds, and build-metadata suffixes are handled consistently across generation and CLI output.
+- OpenAPI generation now includes the generated `/openapi.json` and `/docs` endpoints alongside the health operation.
+
+### Fixed
+- Stabilized OpenAPI generation and parity checks to validate endpoint semantics instead of fragile helper-function shapes.
+- Updated generated file metadata handling and client templates to include the new health functionality cleanly.
+
 ### Security
 - Upgrade Go from 1.26.2 to 1.26.3 across modules and CI to address standard-library vulnerabilities reported by `govulncheck`.
+
+### Documentation
+- Updated release documentation, install/version examples, and blog post notes for the `v0.4.5` release.
 
 ## [v0.4.4] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Upgrade Go from 1.26.2 to 1.26.3 across modules and CI to address standard-library vulnerabilities reported by `govulncheck`.
 
+## [v0.4.4] - 2026-05-07
+
+### Added
+- Regression tests for version string formatting and build metadata resolution in `cmd/fabrica/main_version_test.go`.
+
+### Changed
+- `fabrica version` and Cobra's built-in version output now fall back to Go build metadata when linker-provided version fields are unset.
+  - Resolves the module version from `debug.ReadBuildInfo()`.
+  - Fills commit and build time from VCS settings when available.
+
+### Documentation
+- Updated installation, CLI, release, and version examples for the `v0.4.4` release.
+
+## [v0.4.3] - 2026-05-05
+
+### Added
+- `fabrica init --dir` (`-d`) to create or target a working directory explicitly, improving automation and MCP-driven project setup.
+
+### Fixed
+- `fabrica generate` no longer rewrites generated files when the only differences are generated headers or timestamps.
+  - Reduces no-op diffs in generated projects.
+  - Suppresses misleading "generated" output for unchanged files.
+
+### Changed
+- Project initialization now derives the project base name from the final path component when creating nested target directories.
+
+## [v0.4.2] - 2026-05-03
+
+### Added
+- Built-in `fabrica mcp` server support, implemented on top of the upstream MCP SDK.
+  - Supports project inspection, validation, initialization, resource/schema definition, API version management, code generation, dependency sync, build, test, and smoke-test workflows.
+  - Adds protocol negotiation and stdio handling for MCP clients, including `Content-Length` framed I/O.
+- Comprehensive MCP test coverage for initialization, tool listing, tool validation, schema updates, dry-run behavior, and protocol handling.
+- Generated OpenAPI extensions support, including a template stub and a dedicated guide for customizing generated OpenAPI output.
+
+### Changed
+- Event bus startup now only calls `Start` when the configured bus implements that interface.
+- Event-enabled scaffolding currently validates against the in-memory event bus implementation.
+
+### Documentation
+- Added the MCP command reference in `docs/reference/mcp.md`.
+- Added the OpenAPI extensions guide in `docs/guides/openapi-extensions.md`.
+- Updated CLI references and release docs for MCP and OpenAPI extension workflows.
+
 ## [v0.4.1] - 2026-04-26
 
 ### Changed
@@ -290,7 +334,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storage system architecture documentation
 - Getting started guide
 
-[Unreleased]: https://github.com/openchami/fabrica/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/openchami/fabrica/compare/v0.4.5...HEAD
+[v0.4.5]: https://github.com/openchami/fabrica/compare/v0.4.4...v0.4.5
 [v0.4.4]: https://github.com/openchami/fabrica/compare/v0.4.3...v0.4.4
 [v0.4.3]: https://github.com/openchami/fabrica/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/openchami/fabrica/compare/v0.4.1...v0.4.2

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Fabrica is a powerful code generation tool that accelerates API development by t
 
 ## 📦 Installation
 
-### Latest Release (v0.4.4)
+### Latest Release (v0.4.5)
 
 **macOS/Linux:**
 ```bash
 # Direct download and install
-curl -L https://github.com/openchami/fabrica/releases/download/v0.4.4/fabrica-$(uname -s)-$(uname -m) -o fabrica
+curl -L https://github.com/openchami/fabrica/releases/download/v0.4.5/fabrica-$(uname -s)-$(uname -m) -o fabrica
 chmod +x fabrica
 sudo mv fabrica /usr/local/bin/
 
@@ -70,7 +70,7 @@ fabrica version
 
 **Using Go:**
 ```bash
-go install github.com/openchami/fabrica/cmd/fabrica@v0.4.4
+go install github.com/openchami/fabrica/cmd/fabrica@v0.4.5
 ```
 
 ### Development Version
@@ -342,7 +342,7 @@ We welcome contributions from the community! Here's how to get involved:
 
 ## 🏷️ Releases & Roadmap
 
-**Current Version:** [v0.4.4](https://github.com/openchami/fabrica/releases/tag/v0.4.4)
+**Current Version:** [v0.4.5](https://github.com/openchami/fabrica/releases/tag/v0.4.5)
 
 **📅 Recent Updates:**
 - ✅ Hub/Spoke API versioning with automatic conversion

--- a/USAGE.md
+++ b/USAGE.md
@@ -28,7 +28,7 @@ fabrica version
 
 **Expected output:**
 ```
-Fabrica version v0.4.4
+Fabrica version v0.4.5
   commit: <git-sha>
   built: <timestamp>
 ```

--- a/docs/_posts/2025-11-04-basic-crud.md
+++ b/docs/_posts/2025-11-04-basic-crud.md
@@ -11,7 +11,7 @@ description: "How the CLI and Go library help you use your API the same way ever
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 APIs are easier to use when the client is predictable. You should not have to remember custom flags or one‑off scripts. Fabrica generates two clients that match your server: a CLI and a Go library. They share patterns and types, so your shell steps and your code read the same way.
 

--- a/docs/_posts/2025-11-04-cloud-events.md
+++ b/docs/_posts/2025-11-04-cloud-events.md
@@ -11,7 +11,7 @@ description: "How Fabrica’s event system lets you model and drive resource sta
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 Events let your API tell the world what changed. In Fabrica, that stream becomes more than a log. It is a simple way to model a resource’s state and move it forward. When a resource is created, updated, or deleted, the server publishes an event. When Status changes in a meaningful way, you can publish a condition change. Other parts of your system can subscribe and react.
 

--- a/docs/_posts/2025-11-04-pluggable-storage.md
+++ b/docs/_posts/2025-11-04-pluggable-storage.md
@@ -11,7 +11,7 @@ description: "How the storage contract lets you swap file and database backends 
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 Fabrica generates REST services from Kubernetes‑style resources. The shape is always the same: APIVersion, Kind, Metadata, Spec, and Status. Handlers, routes, models, and the client are generated from templates. What you store those resources in is up to you. The storage layer is pluggable, so you can start with files and move to a database later without rewriting your API.
 

--- a/docs/_posts/2025-11-04-rack-reconciliation.md
+++ b/docs/_posts/2025-11-04-rack-reconciliation.md
@@ -11,7 +11,7 @@ description: "A gentle look at controllers that react to change and keep resourc
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 Some jobs are better done by the system than by users clicking through steps. Reconciliation makes this possible. You declare what you want in Spec, and a controller reads that intent and works until the resource reaches a steady state. When things drift, the controller nudges them back.
 

--- a/docs/_posts/2025-11-04-spec-version-history.md
+++ b/docs/_posts/2025-11-04-spec-version-history.md
@@ -11,11 +11,11 @@ description: "How updating Fabrica and regenerating code lets you grow existing 
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 APIs live for a long time. They grow as your product grows. The hard part is adding features without breaking what you already shipped. Fabrica is built for this kind of steady change. You keep your resource definitions as the source of truth. The generator keeps the rest in sync.
 
-Here is how it works in practice. Update Fabrica to v0.4.4 (or any release v0.3.1 and newer). v0.3.1 added opt-in spec version history. Take a service you built earlier, add the versioning marker to one resource, and run the generator again. The server, storage helpers, client library, and CLI pick up version endpoints and commands. Your custom code stays where it is.
+Here is how it works in practice on current Fabrica releases. Hub/spoke API versioning handles external API evolution, while spec version history remains an opt-in resource feature that records spec snapshots over time. Update Fabrica to v0.4.5, add the versioning marker to a resource, and run the generator again. The server, storage helpers, client library, and CLI pick up version endpoints and commands without changing your handwritten resource code.
 
 Under the hood, the CLI flag `--with-versioning` in `cmd/fabrica/add.go` emits a resource marker. The generator tags that resource (`pkg/codegen/generator.go`). Templates extend storage and handlers: snapshots and helpers come from `pkg/codegen/templates/storage/file.go.tmpl`; handlers that set `status.version` live in `pkg/codegen/templates/server/handlers.go.tmpl`. Client methods and CLI subcommands come from `pkg/codegen/templates/client/client.go.tmpl` and `client/cmd.go.tmpl`.
 

--- a/docs/_posts/2025-11-04-status-subresource.md
+++ b/docs/_posts/2025-11-04-status-subresource.md
@@ -11,7 +11,7 @@ description: "Why encoding REST rules in generators leads to steadier, more supp
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 Many API teams say they follow REST, but each team writes it a little differently. Over time, small differences pile up. One service wraps list results in an object, another returns an array. One updates status together with spec, another splits them. These choices matter to users, and they matter even more when you have to support the API for years.
 

--- a/docs/_posts/2025-11-04-welcome-to-fabrica.md
+++ b/docs/_posts/2025-11-04-welcome-to-fabrica.md
@@ -11,7 +11,7 @@ description: "A tour of the server you get from Fabrica and how it helps you shi
 author: "Alex Lovell-Troy"
 ---
 
-> **Note (v0.4.4):** This post predates hub/spoke API versioning and the flattened resource envelope. Some snippets may differ from current generator output.
+> **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 ## Context
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -26,7 +26,7 @@ Verify installation:
 
 ```bash
 fabrica --version
-# Output: fabrica version v0.4.4
+# Output: fabrica version v0.4.5
 ```
 
 ## Create Your First API

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -52,7 +52,7 @@ Verify installation:
 
 ```bash
 fabrica --version
-# Output: fabrica version v0.4.4
+# Output: fabrica version v0.4.5
 ```
 
 ## Step 1: Initialize Your Project

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -402,12 +402,12 @@ fabrica version
 
 **Output (release build):**
 ```
-Fabrica version v0.4.4
+Fabrica version v0.4.5
 ```
 
 **Output (build from source or CI with VCS metadata):**
 ```
-Fabrica version v0.4.4
+Fabrica version v0.4.5
   commit: abc123def456
   built:  2026-05-07T10:00:00Z
 ```

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -212,7 +212,7 @@ Before tagging a release, ensure the following readiness criteria are met:
 
 - [ ] **Previous version → current version upgrade** is tested:
   - Generate project with previous Fabrica version (e.g., v0.3.1)
-  - Run `fabrica generate` with current CLI version (v0.4.4)
+  - Run `fabrica generate` with current CLI version (v0.4.5)
   - Verify generated code compiles and basic operations work
 
 ### Binary Smoke Testing


### PR DESCRIPTION
This pull request updates the project for the v0.4.5 release, focusing on version bumping, documentation refreshes, and ensuring all references and guides reflect the new version. It also updates several blog posts and documentation to clarify new behaviors and features introduced since v0.4.4, especially around API versioning and resource envelopes.

**Release and Versioning Updates:**

- Added release notes for v0.4.4, summarizing new features, fixes, and documentation changes. Updated the release comparison links to prepare for v0.4.5. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R61) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL293-R338)
- Updated all version references in installation instructions, CLI usage, and documentation from v0.4.4 to v0.4.5. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L345-R345) [[4]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dL31-R31) [[5]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L405-R410) [[6]](diffhunk://#diff-cfabf1cf40f1208bf2a9e4198f0fa64a0fb3de07c1e2a005a3965e1a699a9e37L29-R29) [[7]](diffhunk://#diff-0a519ea24788b99a6c19c0f020778ab292d7da07c6a65689a753833cec2346a0L55-R55) [[8]](diffhunk://#diff-85e1bc53647f7e90e5fe6da705623a2fe9be002bc165644ee04ce683525ce887L215-R215)

**Documentation and Blog Post Refreshes:**

- Revised all blog posts in `docs/_posts/` to indicate they have been updated for v0.4.5, clarifying that code snippets and behaviors now reflect the current hub/spoke API versioning and resource envelope. [[1]](diffhunk://#diff-198ff046f82f78faa515d0ececa3fdb5c756de19256d2ae9f20151ee7b2c2113L14-R14) [[2]](diffhunk://#diff-32c9c73897d6d2a793100852e6cab95d6477d195ef2e378457c61b22de44928fL14-R14) [[3]](diffhunk://#diff-c47b83576d7d462db6aa1339d85c51e50831fef709242b68d751d9c0265fe6cbL14-R14) [[4]](diffhunk://#diff-2949c1696e6f46ea702c86d68da1faf81b7a02d79146a57889cd04a60cf96235L14-R14) [[5]](diffhunk://#diff-3dd55e9517212085fd0f80201395caa49326e0196d62c807ceb0660a76adb121L14-R18) [[6]](diffhunk://#diff-ce0b9d63d7b9dca3c15df05598446ad283dd40655c0efaba66f5bea22791b398L14-R14) [[7]](diffhunk://#diff-121af133a5c761a284b46d2a06b3441b275f08de6764b470b4937067b023fcf0L14-R14)
- Improved the explanation in the API version history blog post to describe how versioning works in v0.4.5, including hub/spoke API versioning and opt-in spec version history.
---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
