### PR TITLE
feat(client): add log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Client log levels: Generated clients now support `--log-level` flag with `debug`, `info`, and `warning` levels for controlling output verbosity
+- Debug logging in client library shows HTTP requests, responses, headers, and bodies for troubleshooting
+- Shell completion for `--log-level` flag in generated clients
+- Comprehensive test coverage for client log level functionality including unit and integration tests
+
 ## [v0.4.5] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Fabrica is a powerful code generation tool that accelerates API development by t
 - **🌐 Cloud-Native Ready** - [Hub/spoke API versioning](docs/guides/versioning.md), conditional requests (ETags), event-driven patterns
 - **🔄 API Versioning (Hub/Spoke)** - Kubebuilder-style versioning with automatic conversion between versions
 - **🏗️ Production Patterns** - Consistent API structure, error handling, and middleware
+- **🔍 Built-in Client Debugging** - Generated CLI with configurable log levels for easy troubleshooting
 
 ## 🎯 Perfect For
 

--- a/cmd/fabrica/client_auth_template_test.go
+++ b/cmd/fabrica/client_auth_template_test.go
@@ -45,3 +45,134 @@ func TestTemplate_ClientCLI_BearerTokenFlagSupport(t *testing.T) {
 		t.Fatalf("cli template must configure client with bearer token")
 	}
 }
+
+func TestTemplate_ClientLibrary_LoggerSupport(t *testing.T) {
+	clientTmpl := mustReadFile(t, "pkg/codegen/templates/client/client.go.tmpl")
+
+	// Check logger field exists in Client struct
+	if !strings.Contains(clientTmpl, "logger     zerolog.Logger") {
+		t.Fatalf("client template must define logger field in Client struct")
+	}
+
+	// Check NewClient signature accepts logger parameter
+	if !strings.Contains(clientTmpl, "func NewClient(baseURL string, httpClient *http.Client, logger zerolog.Logger)") {
+		t.Fatalf("client template NewClient must accept logger parameter")
+	}
+
+	// Check NewClientWithBearerToken signature accepts logger parameter
+	if !strings.Contains(clientTmpl, "func NewClientWithBearerToken(baseURL, bearerToken string, httpClient *http.Client, logger zerolog.Logger)") {
+		t.Fatalf("client template NewClientWithBearerToken must accept logger parameter")
+	}
+
+	// Check DefaultLogger function exists
+	if !strings.Contains(clientTmpl, "func DefaultLogger() zerolog.Logger") {
+		t.Fatalf("client template must provide DefaultLogger function")
+	}
+
+	// Check NewLogger function exists
+	if !strings.Contains(clientTmpl, "func NewLogger(level LogLevel) (zerolog.Logger, error)") {
+		t.Fatalf("client template must provide NewLogger function")
+	}
+
+	// Check debug logging in doRequest method
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msgf(\"%s: %s\", method, u.String())") {
+		t.Fatalf("client template must log request method and URL")
+	}
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msg(\"Request headers:\")") {
+		t.Fatalf("client template must log request headers")
+	}
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msg(\"Request body:\")") {
+		t.Fatalf("client template must log request body")
+	}
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msg(\"Response status: \" + resp.Status)") {
+		t.Fatalf("client template must log response status")
+	}
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msg(\"Response headers:\")") {
+		t.Fatalf("client template must log response headers")
+	}
+	if !strings.Contains(clientTmpl, "c.logger.Debug().Msg(\"Response body:\")") {
+		t.Fatalf("client template must log response body")
+	}
+
+	// Check LogLevel type exists
+	if !strings.Contains(clientTmpl, "type LogLevel string") {
+		t.Fatalf("client template must define LogLevel type")
+	}
+
+	// Check LogLevel constants exist
+	if !strings.Contains(clientTmpl, "LogLevelInfo    LogLevel = \"info\"") {
+		t.Fatalf("client template must define LogLevelInfo constant")
+	}
+	if !strings.Contains(clientTmpl, "LogLevelWarning LogLevel = \"warning\"") {
+		t.Fatalf("client template must define LogLevelWarning constant")
+	}
+	if !strings.Contains(clientTmpl, "LogLevelDebug   LogLevel = \"debug\"") {
+		t.Fatalf("client template must define LogLevelDebug constant")
+	}
+
+	// Check LogLevel methods exist
+	if !strings.Contains(clientTmpl, "func (ll LogLevel) String() string") {
+		t.Fatalf("client template must provide LogLevel.String() method")
+	}
+	if !strings.Contains(clientTmpl, "func (ll *LogLevel) Set(v string) error") {
+		t.Fatalf("client template must provide LogLevel.Set() method")
+	}
+	if !strings.Contains(clientTmpl, "func (ll LogLevel) Type() string") {
+		t.Fatalf("client template must provide LogLevel.Type() method")
+	}
+
+	// Check CompletionLogLevel function exists
+	if !strings.Contains(clientTmpl, "func CompletionLogLevel(cmd *cobra.Command, args []string, toComplete string)") {
+		t.Fatalf("client template must provide CompletionLogLevel function for shell completion")
+	}
+
+	// Check required imports
+	if !strings.Contains(clientTmpl, "\"os\"") {
+		t.Fatalf("client template must import os package")
+	}
+	if !strings.Contains(clientTmpl, "\"github.com/rs/zerolog\"") {
+		t.Fatalf("client template must import github.com/rs/zerolog")
+	}
+	if !strings.Contains(clientTmpl, "\"github.com/spf13/cobra\"") {
+		t.Fatalf("client template must import github.com/spf13/cobra")
+	}
+}
+
+func TestTemplate_ClientCLI_LogLevelFlagSupport(t *testing.T) {
+	cliTmpl := mustReadFile(t, "pkg/codegen/templates/client/cmd.go.tmpl")
+
+	// Check logLevel variable declaration
+	if !strings.Contains(cliTmpl, "logLevel    client.LogLevel") {
+		t.Fatalf("cli template must declare logLevel variable")
+	}
+
+	// Check --log-level flag registration with -l shorthand
+	if !strings.Contains(cliTmpl, "VarP(&logLevel, \"log-level\", \"l\"") {
+		t.Fatalf("cli template must register --log-level flag with -l shorthand")
+	}
+
+	// Check help text for log-level flag
+	if !strings.Contains(cliTmpl, "set verbosity of logs") {
+		t.Fatalf("cli template must document --log-level flag purpose")
+	}
+
+	// Check viper binding
+	if !strings.Contains(cliTmpl, "BindPFlag(\"log-level\"") {
+		t.Fatalf("cli template must bind log-level flag to viper configuration")
+	}
+
+	// Check shell completion registration
+	if !strings.Contains(cliTmpl, "RegisterFlagCompletionFunc(\"log-level\", client.CompletionLogLevel)") {
+		t.Fatalf("cli template must register shell completion for log-level flag")
+	}
+
+	// Check getClient creates logger
+	if !strings.Contains(cliTmpl, "logger, _ := client.NewLogger(logLevel)") {
+		t.Fatalf("cli template getClient must create logger with NewLogger")
+	}
+
+	// Check logger is passed to NewClient
+	if !strings.Contains(cliTmpl, "c, err := client.NewClient(serverURL, nil, logger)") {
+		t.Fatalf("cli template must pass logger to NewClient")
+	}
+}

--- a/docs/_posts/2025-11-04-basic-crud.md
+++ b/docs/_posts/2025-11-04-basic-crud.md
@@ -11,6 +11,8 @@ description: "How the CLI and Go library help you use your API the same way ever
 author: "Alex Lovell-Troy"
 ---
 
+> **Updated for v0.5.6:** This post has been updated to document the new client log level feature for debugging API interactions.
+
 > **Updated for v0.4.5:** This post has been reviewed and refreshed for Fabrica's current hub/spoke API versioning and flattened resource envelope behavior.
 
 APIs are easier to use when the client is predictable. You should not have to remember custom flags or one‑off scripts. Fabrica generates two clients that match your server: a CLI and a Go library. They share patterns and types, so your shell steps and your code read the same way.
@@ -26,6 +28,22 @@ The Go client library comes from `pkg/codegen/templates/client/client.go.tmpl`. 
 The CLI creates a typed client with `client.NewClient` and calls methods that mirror your resources. The methods issue HTTP requests to the server’s generated routes (`pkg/codegen/templates/server/routes.go.tmpl`) and unmarshal responses into your types from `apis/<group>/<version>/...`. Status operations go to `/status` endpoints to avoid spec conflicts.
 
 When you enable spec versioning on a resource, the generator adds version helpers and subcommands. The Go client gets `List<Resource>Versions`, `Get<Resource>Version`, and `Delete<Resource>Version`, and the CLI nests them under `<resource> versions ...`. These come from the same templates, so you do not maintain them by hand.
+
+## Debugging with log levels
+
+The client supports three log levels controlled by the `--log-level` (or `-l`) flag: `debug`, `info`, and `warning` (default). Debug level shows HTTP requests and responses, headers, and body content. This helps when troubleshooting API interactions or understanding what the client sends.
+
+```bash
+go run ./cmd/client/ --log-level debug device list
+```
+
+The debug output appears on stderr, so you can redirect it separately from the JSON output:
+
+```bash
+go run ./cmd/client/ device list -o json > devices.json 2> debug.log
+```
+
+The client creates a console logger that writes to stderr without timestamps, making it easy to read during development.
 
 ## Trade‑offs and limits
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -248,6 +248,29 @@ curl -X PUT http://localhost:8080/books/boo-abc123def456 \
 curl -X DELETE http://localhost:8080/books/boo-abc123def456
 ```
 
+### Using the Generated Client
+
+Fabrica also generates a CLI client in `cmd/client/` that provides a convenient way to interact with your API:
+
+```bash
+# List books
+go run ./cmd/client/ book list
+
+# List books with debug logging
+go run ./cmd/client/ --log-level debug book list
+
+# Create a book
+go run ./cmd/client/ book create --spec '{"title":"The Go Programming Language","author":"Donovan & Kernighan","price":44.99,"inStock":true}' -o json
+
+# Get output as JSON and process with jq
+go run ./cmd/client/ book list -o json | jq '.[0].metadata.uid'
+
+# Debug API interactions
+go run ./cmd/client/ -l debug book create --spec '{"title":"Test Book"}' -o json 2> debug.log
+```
+
+The `--log-level debug` flag is particularly useful when troubleshooting API interactions, as it shows all HTTP requests and responses including headers and bodies.
+
 ## Understanding the Resource Model
 
 Fabrica uses a Kubernetes-style resource model with a flattened envelope pattern:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -674,6 +674,96 @@ DATABASE_URL="postgres://user:pass@localhost/mydb" go run ./cmd/server/
 
 ---
 
+## Generated Client CLI
+
+After running `fabrica generate`, your project includes a fully functional CLI client in `cmd/client/main.go`. The client provides commands for all CRUD operations on your resources.
+
+### Client Global Flags
+
+The generated client supports these global flags:
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--server` | `-s` | string | `http://localhost:8080` | API server URL |
+| `--timeout` | `-t` | duration | `30s` | Request timeout |
+| `--output` | `-o` | string | `table` | Output format: `table`, `json`, `yaml` |
+| `--log-level` | `-l` | string | `warning` | Log verbosity: `debug`, `info`, `warning` |
+| `--token` | | string | | JWT bearer token for authentication |
+| `--version` | `-v` | string | | API version to request (e.g., `v1`, `v2beta1`) |
+
+### Log Levels
+
+The `--log-level` flag controls the verbosity of client logging:
+
+- **`warning`** (default) - Only shows warnings and errors
+- **`info`** - Shows informational messages plus warnings/errors
+- **`debug`** - Shows detailed HTTP request/response information including:
+  - HTTP method and URL
+  - Request and response headers
+  - Request and response bodies
+  - Error details
+
+**Examples:**
+
+```bash
+# Default (warning level)
+go run ./cmd/client/ device list
+
+# Debug mode for troubleshooting
+go run ./cmd/client/ --log-level debug device list
+
+# Using shorthand
+go run ./cmd/client/ -l debug device create --spec '{"name":"test"}'
+
+# Redirect debug logs separately from output
+go run ./cmd/client/ -l debug device list -o json > output.json 2> debug.log
+```
+
+### Tab Completion
+
+The generated client supports shell completion for the `--log-level` flag:
+
+```bash
+# Bash
+source <(go run ./cmd/client/ completion bash)
+
+# Zsh
+go run ./cmd/client/ completion zsh > "${fpath[1]}/_client"
+
+# Then tab complete:
+go run ./cmd/client/ --log-level <TAB>
+# Shows: debug info warning
+```
+
+### Resource Commands
+
+For each resource in your API, the client generates subcommands:
+
+```bash
+# List resources
+go run ./cmd/client/ device list
+
+# Get specific resource
+go run ./cmd/client/ device get <uid>
+
+# Create resource
+go run ./cmd/client/ device create --spec '{"name":"device-01"}'
+
+# Update resource
+go run ./cmd/client/ device update <uid> --spec '{"name":"updated"}'
+
+# Patch resource
+go run ./cmd/client/ device patch <uid> --spec '{"name":"patched"}'
+
+# Delete resource
+go run ./cmd/client/ device delete <uid>
+
+# Update status (if status subresource is enabled)
+go run ./cmd/client/ device update-status <uid> --spec '{"ready":true}'
+```
+
+---
+
 ## Common Errors
 
 ### "Command not found: fabrica"

--- a/pkg/codegen/templates/client/client.go.tmpl
+++ b/pkg/codegen/templates/client/client.go.tmpl
@@ -23,7 +23,7 @@
 //   - DeleteResource(ctx, uid) - Delete resource
 //
 // Usage example:
-//   client, err := client.NewClient("http://localhost:8080", nil)
+//   client, err := client.NewClient("http://localhost:8080", nil, client.DefaultLogger())
 //   if err != nil {
 //       log.Fatal(err)
 //   }
@@ -39,7 +39,7 @@
 //      httpClient := &http.Client{
 //          Transport: &AuthTransport{Token: "your-token"},
 //      }
-//      client, _ := client.NewClient(baseURL, httpClient)
+//      client, _ := client.NewClient(baseURL, httpClient, client.DefaultLogger)
 //
 // To add custom headers:
 //   1. Modify doRequest method to accept header options
@@ -64,16 +64,24 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 {{if $hasVersioning}}	"time"{{end}}
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+{{if .UniqueImports}}
+
 	{{range .UniqueImports}}"{{.Path}}"
 	{{end}}
+{{end}}
 )
 
 // Client provides access to the inventory API
 type Client struct {
 	baseURL    *url.URL
 	httpClient *http.Client
+	logger     zerolog.Logger
 	version    string // Optional API version for Accept/Content-Type headers
 	bearerToken string // Optional JWT bearer token for Authorization header
 }
@@ -88,7 +96,7 @@ type ErrorResponse struct {
 type HealthResponse map[string]interface{}
 
 // NewClient creates a new API client
-func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+func NewClient(baseURL string, httpClient *http.Client, logger zerolog.Logger) (*Client, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
@@ -101,12 +109,13 @@ func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
 	return &Client{
 		baseURL:    u,
 		httpClient: httpClient,
+		logger:     logger,
 	}, nil
 }
 
 // NewClientWithBearerToken creates a new API client configured with a JWT bearer token.
-func NewClientWithBearerToken(baseURL, bearerToken string, httpClient *http.Client) (*Client, error) {
-	c, err := NewClient(baseURL, httpClient)
+func NewClientWithBearerToken(baseURL, bearerToken string, httpClient *http.Client, logger zerolog.Logger) (*Client, error) {
+	c, err := NewClient(baseURL, httpClient, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -168,11 +177,64 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body in
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
 	}
 
+	// Debug info for request
+	c.logger.Debug().Msgf("%s: %s", method, u.String())
+	if len(req.Header) > 0 {
+		c.logger.Debug().Msg("Request headers:")
+		for k, v := range req.Header {
+			c.logger.Debug().Msgf("  %s: %s", k, v)
+		}
+	} else {
+		c.logger.Debug().Msg("No headers in request")
+	}
+	if req.ContentLength > 0 {
+		var reqBodyCopy bytes.Buffer
+		reqBodyReader := io.TeeReader(req.Body, &reqBodyCopy)
+		reqBodyBytes , err := io.ReadAll(reqBodyReader)
+		if err != nil {
+			c.logger.Error().Err(err).Msg("failed to read body for debug message")
+		}
+		c.logger.Debug().Msg("Request body:")
+		c.logger.Debug().Msgf("%s", string(reqBodyBytes))
+		req.Body = io.NopCloser(bytes.NewReader(reqBodyBytes))
+	} else {
+		c.logger.Debug().Msg("No body in request")
+	}
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Debug info for response
+	if resp != nil {
+		c.logger.Debug().Msg("Response status: " + resp.Status)
+		if len(resp.Header) > 0 {
+			c.logger.Debug().Msg("Response headers:")
+			for k, v := range resp.Header {
+				c.logger.Debug().Msgf("  %s: %s", k, v)
+			}
+		} else {
+			c.logger.Debug().Msg("No headers in response")
+		}
+		respBodyLen := resp.ContentLength
+		if respBodyLen > 0 {
+			var respBodyCopy bytes.Buffer
+			respBodyReader := io.TeeReader(resp.Body, &respBodyCopy)
+			respBodyBytes, err := io.ReadAll(respBodyReader)
+			if err != nil {
+				c.logger.Error().Err(err).Msg("failed to read body for debug message")
+			}
+			c.logger.Debug().Msg("Response body:")
+			c.logger.Debug().Msgf("%s", string(respBodyBytes))
+			resp.Body = io.NopCloser(bytes.NewReader(respBodyBytes))
+		} else {
+			c.logger.Debug().Msg("No body in response")
+		}
+	} else {
+		c.logger.Debug().Msg("Response was nil")
+	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -390,3 +452,82 @@ func (c *Client) Delete{{.Name}}Version(ctx context.Context, uid, versionID stri
 	return nil
 }
 {{end}}{{end}}{{end}}
+
+// LogLevel represents a valid log level
+type LogLevel string
+
+const (
+	LogLevelInfo    LogLevel = "info"
+	LogLevelWarning LogLevel = "warning"
+	LogLevelDebug   LogLevel = "debug"
+)
+
+var (
+	LogLevelHelp = map[string]string{
+		string(LogLevelInfo):    "Info log level",
+		string(LogLevelWarning): "Warning log level",
+		string(LogLevelDebug):   "Debug log level",
+	}
+)
+
+func (ll LogLevel) String() string {
+	return string(ll)
+}
+
+func (ll *LogLevel) Set(v string) error {
+	switch LogLevel(v) {
+	case LogLevelInfo,
+		LogLevelWarning,
+		LogLevelDebug:
+		*ll = LogLevel(v)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %v", []LogLevel{
+			LogLevelInfo,
+			LogLevelWarning,
+			LogLevelDebug,
+		})
+	}
+}
+
+func (ll LogLevel) Type() string {
+	return "LogLevel"
+}
+
+// CompletionLogLevel is the cobra completion function for the --log-level
+// flag.
+func CompletionLogLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var helpSlice []string
+	for k, v := range LogLevelHelp {
+		helpSlice = append(helpSlice, fmt.Sprintf("%s\t%s", k, v))
+	}
+	return helpSlice, cobra.ShellCompDirectiveDefault
+}
+
+func DefaultLogger() zerolog.Logger {
+	cw := zerolog.ConsoleWriter{
+		Out:          os.Stderr,
+		PartsExclude: []string{zerolog.TimestampFieldName},
+	}
+	return zerolog.New(cw).Level(zerolog.WarnLevel)
+}
+
+func NewLogger(level LogLevel) (zerolog.Logger, error) {
+	cw := zerolog.ConsoleWriter{
+		Out:          os.Stderr,
+		PartsExclude: []string{zerolog.TimestampFieldName},
+	}
+	l := zerolog.New(cw)
+	var ll zerolog.Level
+	switch level {
+	case LogLevelWarning:
+		ll = zerolog.WarnLevel
+	case LogLevelInfo:
+		ll = zerolog.InfoLevel
+	case LogLevelDebug:
+		ll = zerolog.DebugLevel
+	default:
+		return DefaultLogger(), fmt.Errorf("invalid log level: %s", level)
+	}
+	return l.Level(ll), nil
+}

--- a/pkg/codegen/templates/client/cmd.go.tmpl
+++ b/pkg/codegen/templates/client/cmd.go.tmpl
@@ -83,12 +83,13 @@ import (
 )
 
 var (
-	cfgFile    string
-	serverURL  string
-	timeout    time.Duration
-	output     string
-	apiVersion string
+	cfgFile     string
+	serverURL   string
+	timeout     time.Duration
+	output      string
+	apiVersion  string
 	bearerToken string
+	logLevel    client.LogLevel
 )
 
 func main() {
@@ -114,6 +115,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "table", "output format: table, json, yaml")
 	rootCmd.PersistentFlags().StringVarP(&apiVersion, "version", "v", "", "API version to request (e.g., v1, v2beta1)")
 	rootCmd.PersistentFlags().StringVar(&bearerToken, "token", "", "JWT bearer token")
+	rootCmd.PersistentFlags().VarP(&logLevel, "log-level", "l", "set verbosity of logs (e.g., info, warning, debug)")
+
+	// Register shell completion functions
+	rootCmd.RegisterFlagCompletionFunc("log-level", client.CompletionLogLevel)
 
 	// Bind flags to viper
 	viper.BindPFlag("server", rootCmd.PersistentFlags().Lookup("server"))
@@ -121,6 +126,7 @@ func init() {
 	viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 	viper.BindPFlag("version", rootCmd.PersistentFlags().Lookup("version"))
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
+	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
 
 	// Environment variable support
 	viper.SetEnvPrefix("{{toUpper .ProjectName}}")
@@ -154,7 +160,9 @@ func initConfig() {
 
 func getClient() (*client.Client, error) {
 	serverURL := viper.GetString("server")
-	c, err := client.NewClient(serverURL, nil)
+	// Error will cause default logger, which is handled by NewClient()
+	logger, _ := client.NewLogger(logLevel)
+	c, err := client.NewClient(serverURL, nil, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/client_binary_test.go
+++ b/test/integration/client_binary_test.go
@@ -5,7 +5,9 @@
 package integration
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -258,6 +260,207 @@ func (s *ClientBinaryTestSuite) TestClientEnvironmentConfiguration() {
 	output, err := project.RunClientBinary(clientBinary, "config", "list")
 	s.Require().NoError(err, "Client should respect environment configuration")
 	s.Require().NotEmpty(string(output), "Client should produce output")
+}
+
+// TestClientLogLevelFlag verifies that the --log-level flag is properly implemented
+func (s *ClientBinaryTestSuite) TestClientLogLevelFlag() {
+	project := s.createProject("client-loglevel-test", "github.com/test/client-loglevel", "file")
+
+	// Setup
+	err := project.Initialize(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.AddResource(s.fabricaBinary, "Volume")
+	s.Require().NoError(err)
+
+	err = project.Generate(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.StartServerRuntime()
+	s.Require().NoError(err)
+
+	clientBinary, err := project.BuildClientBinary()
+	s.Require().NoError(err)
+
+	// Test 1: Help contains --log-level
+	output, err := project.RunClientBinary(clientBinary, "--help")
+	s.Require().NoError(err)
+	s.Require().Contains(string(output), "--log-level", "Help should document --log-level flag")
+	s.Require().Contains(string(output), "-l", "Help should document -l shorthand")
+
+	// Test 2: Valid log levels work
+	for _, level := range []string{"info", "warning", "debug"} {
+		output, err := project.RunClientBinary(clientBinary, "--log-level", level, "volume", "list")
+		s.Require().NoError(err, "volume list with --log-level %s should succeed", level)
+		s.Require().NotEmpty(string(output))
+	}
+
+	// Test 3: Invalid log level fails
+	output, err = project.RunClientBinary(clientBinary, "--log-level", "invalid", "volume", "list")
+	s.Require().Error(err, "Invalid log level should fail")
+	s.Require().Contains(string(output), "must be one of", "Error should explain valid values")
+}
+
+// TestClientLogLevelOutput verifies that debug logs actually appear in stderr
+func (s *ClientBinaryTestSuite) TestClientLogLevelOutput() {
+	project := s.createProject("client-log-output-test", "github.com/test/client-log-output", "file")
+
+	// Setup
+	err := project.Initialize(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.AddResource(s.fabricaBinary, "Widget")
+	s.Require().NoError(err)
+
+	err = project.Generate(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.StartServerRuntime()
+	s.Require().NoError(err)
+
+	clientBinary, err := project.BuildClientBinary()
+	s.Require().NoError(err)
+
+	// Test 1: Debug level shows logs
+	cmd := exec.Command(clientBinary, "--server", project.ServerURL, "--log-level", "debug", "widget", "list")
+	cmd.Dir = project.Dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(output)
+
+	stderrStr := stderr.String()
+	s.Require().Contains(stderrStr, "GET:", "Debug logs should show HTTP method")
+	s.Require().Contains(stderrStr, "Response status:", "Debug logs should show response status")
+
+	// Test 2: Warning level does NOT show debug logs
+	cmd = exec.Command(clientBinary, "--server", project.ServerURL, "--log-level", "warning", "widget", "list")
+	cmd.Dir = project.Dir
+	stderr.Reset()
+	cmd.Stderr = &stderr
+	output, err = cmd.Output()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(output)
+
+	stderrStr = stderr.String()
+	s.Require().NotContains(stderrStr, "GET:", "Warning level should not show debug logs")
+	s.Require().NotContains(stderrStr, "Response status:", "Warning level should not show debug logs")
+
+	// Test 3: Info level does NOT show debug logs
+	cmd = exec.Command(clientBinary, "--server", project.ServerURL, "--log-level", "info", "widget", "list")
+	cmd.Dir = project.Dir
+	stderr.Reset()
+	cmd.Stderr = &stderr
+	output, err = cmd.Output()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(output)
+
+	stderrStr = stderr.String()
+	s.Require().NotContains(stderrStr, "GET:", "Info level should not show debug logs")
+	s.Require().NotContains(stderrStr, "Response status:", "Info level should not show debug logs")
+}
+
+// TestClientLogLevelShorthand verifies the -l shorthand works
+func (s *ClientBinaryTestSuite) TestClientLogLevelShorthand() {
+	project := s.createProject("client-shorthand-test", "github.com/test/client-shorthand", "file")
+
+	// Setup
+	err := project.Initialize(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.AddResource(s.fabricaBinary, "Config")
+	s.Require().NoError(err)
+
+	err = project.Generate(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.StartServerRuntime()
+	s.Require().NoError(err)
+
+	clientBinary, err := project.BuildClientBinary()
+	s.Require().NoError(err)
+
+	// Test -l shorthand
+	output, err := project.RunClientBinary(clientBinary, "-l", "debug", "config", "list")
+	s.Require().NoError(err, "-l shorthand should work")
+	s.Require().NotEmpty(string(output))
+
+	// Verify it's the same as --log-level (both should work)
+	output2, err := project.RunClientBinary(clientBinary, "--log-level", "debug", "config", "list")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(string(output2))
+}
+
+// TestClientLogLevelEnvironmentVariable verifies log level via command-line flag works
+// Note: Environment variable support for custom flag types (like LogLevel) requires
+// additional plumbing in the generated code. This test verifies the flag works explicitly.
+func (s *ClientBinaryTestSuite) TestClientLogLevelEnvironmentVariable() {
+	project := s.createProject("clientenvlog", "github.com/test/clientenvlog", "file")
+
+	// Setup
+	err := project.Initialize(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.AddResource(s.fabricaBinary, "Service")
+	s.Require().NoError(err)
+
+	err = project.Generate(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.StartServerRuntime()
+	s.Require().NoError(err)
+
+	clientBinary, err := project.BuildClientBinary()
+	s.Require().NoError(err)
+
+	// Test that log level flag works with explicit setting
+	// (Environment variables for custom flag types would require additional template changes)
+	cmd := exec.Command(clientBinary, "--server", project.ServerURL, "--log-level", "debug", "service", "list")
+	cmd.Dir = project.Dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(output)
+
+	stderrStr := stderr.String()
+	s.Require().Contains(stderrStr, "GET:", "Debug log level via flag should show HTTP requests")
+}
+
+// TestClientLogLevelEdgeCases tests edge cases like empty log level, case sensitivity
+func (s *ClientBinaryTestSuite) TestClientLogLevelEdgeCases() {
+	project := s.createProject("client-edge-test", "github.com/test/client-edge", "file")
+
+	// Setup
+	err := project.Initialize(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.AddResource(s.fabricaBinary, "Node")
+	s.Require().NoError(err)
+
+	err = project.Generate(s.fabricaBinary)
+	s.Require().NoError(err)
+
+	err = project.StartServerRuntime()
+	s.Require().NoError(err)
+
+	clientBinary, err := project.BuildClientBinary()
+	s.Require().NoError(err)
+
+	// Test 1: No log level flag (default should work)
+	output, err := project.RunClientBinary(clientBinary, "node", "list")
+	s.Require().NoError(err, "Default log level should work")
+	s.Require().NotEmpty(string(output))
+
+	// Test 2: Case sensitivity (should fail if uppercase)
+	output, err = project.RunClientBinary(clientBinary, "--log-level", "DEBUG", "node", "list")
+	s.Require().Error(err, "Log levels should be case-sensitive (lowercase only)")
+	s.Require().Contains(string(output), "must be one of", "Error should explain valid values")
+
+	// Test 3: Whitespace should be rejected
+	output, err = project.RunClientBinary(clientBinary, "--log-level", " debug ", "node", "list")
+	s.Require().Error(err, "Whitespace in log level should fail")
 }
 
 // Run the test suite


### PR DESCRIPTION
Currently, there is no way to control logging in the generated client. It would be useful to, at minimum, have a flag that controls log verbosity. One common example is to examine the request (URI, headers, body) being sent to services and that of any response received.

Add a `--log-level`/`-l` flag to the generated client which supports values of `warning` (default), `info`, or `debug`. In the client library, add a parameter to the `NewClient()` function that takes a `zerolog.Logger` to support custom logging configurations.

This has been tested with boot-service:

```
$ go run ./cmd/client -l debug health
DBG GET: http://localhost:8080/health
DBG Request headers:
DBG   Accept: [application/json]
DBG No body in request
DBG Response status: 200 OK
DBG Response headers:
DBG   Content-Type: [application/json]
DBG   Date: [Tue, 26 May 2026 15:55:55 GMT]
DBG   Content-Length: [40]
DBG Response body:
DBG {"status":"ok","service":"boot-service"}
{
  "service": "boot-service",
  "status": "ok"
}
```

as well as using the `ochami` CLI compiled against the regenerated boot-service:

```
$ ./ochami boot service status -l debug -L basic --cluster-uri http://localhost:8080
DEBUG | cli.go:193 > logging has been initialized
DEBUG | cli.go:329 > using base URI from default cluster demo
DEBUG | cli.go:359 > using base URI passed on command line
DEBUG | cli.go:411 > using API version from  in default cluster demo
DEBUG | client_generated.go:173 > GET: http://localhost:8080/boot/health
DEBUG | client_generated.go:175 > Request headers:
DEBUG | client_generated.go:177 >   Accept: [application/json]
DEBUG | client_generated.go:192 > No body in request
DEBUG | client_generated.go:203 > Response status: 404 Not Found
DEBUG | client_generated.go:205 > Response headers:
DEBUG | client_generated.go:207 >   Content-Type: [text/plain; charset=utf-8]
DEBUG | client_generated.go:207 >   X-Content-Type-Options: [nosniff]
DEBUG | client_generated.go:207 >   Date: [Tue, 26 May 2026 16:04:42 GMT]
DEBUG | client_generated.go:207 >   Content-Length: [19]
DEBUG | client_generated.go:220 > Response body:
DEBUG | client_generated.go:221 > 404 page not found
```

(404 is returned because I haven't configured boot-service paths locally, I just wanted to test the logging output.)

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
