### PR TITLE
bugfix(codegen): preserve logger field in With* methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `client.With*()` functions coppy logger object correctly
+
 ## [v0.4.6] - 2026-05-27
 
 ### Added

--- a/pkg/codegen/templates/client/client.go.tmpl
+++ b/pkg/codegen/templates/client/client.go.tmpl
@@ -125,10 +125,11 @@ func NewClientWithBearerToken(baseURL, bearerToken string, httpClient *http.Clie
 // WithVersion returns a new client configured to use a specific API version
 func (c *Client) WithVersion(version string) *Client {
 	return &Client{
-		baseURL:    c.baseURL,
-		httpClient: c.httpClient,
-		version:    version,
+		baseURL:     c.baseURL,
+		httpClient:  c.httpClient,
+		version:     version,
 		bearerToken: c.bearerToken,
+		logger:      c.logger,
 	}
 }
 
@@ -139,6 +140,7 @@ func (c *Client) WithBearerToken(token string) *Client {
 		httpClient:  c.httpClient,
 		version:     c.version,
 		bearerToken: token,
+		logger:      c.logger,
 	}
 }
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

The `WithVersion()` and `WithBearerToken()` methods now correctly copy
the logger field when creating new Client instances.

Previously, these methods omitted the logger field, resulting in
clients with zero-value loggers that produced no debug output.

This fix ensures all `Client` struct fields are preserved when
creating new instances via `With*` methods.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
