### PR TITLE
chore: upgrade Go: 1.26.3 -> 1.26.4

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           check-latest: true
 
       - name: Run govulncheck

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: false
 
       # Temporarily rename examples directory to exclude it from linting

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.26.3']
+        go-version: ['1.26.4']
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/openchami/fabrica
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/openchami/fabrica/test/integration
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/openchami/fabrica => ../..
 


### PR DESCRIPTION
### Description

Mitigate GO-2026-5036 and [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) vulnerabilities in Go 1.26.3 standard library by upgrading to Go 1.26.4. See https://github.com/OpenCHAMI/fabrica/pull/60#issuecomment-4722655929.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [x] Dependency update
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
