### PR TITLE
chore: upgrade Go version to 1.26.5 in workflows and go.mod

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
 
       - name: Run govulncheck

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
 
       # Temporarily rename examples directory to exclude it from linting

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.26.4']
+        go-version: ['1.26.5']
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/openchami/fabrica
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2


### PR DESCRIPTION
### Description

This pull request updates the Go version used across the project from `1.26.4` to `1.26.5`. This change ensures that all workflows, builds, and dependency management use the latest patch release, which may include important bug fixes and security updates.

Go version updates:

* Updated the Go version in the `go.mod` file to `1.26.5`.
* Updated the Go version in GitHub Actions workflows, including `govulncheck.yaml`, `lint.yaml`, `regression-tests.yml`, and `release.yaml`, to use `1.26.5` instead of `1.26.4`. [[1]](diffhunk://#diff-106a19aa5c56313f877754240b29645f7eaebafaa6782a9adad1c640369eb232L29-R29) [[2]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL33-R33) [[3]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79L24-R24) [[4]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL29-R29)


### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  


### Type of Change

- [X] Chore
- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
