### PR TITLE
feat(cli): support bulk delete for generated client

### DIFF
--- a/pkg/codegen/templates/client/cmd.go.tmpl
+++ b/pkg/codegen/templates/client/cmd.go.tmpl
@@ -552,9 +552,13 @@ Attempts to patch metadata or status fields will be ignored.`,
 }
 
 var {{toLower .Name}}DeleteCmd = &cobra.Command{
-	Use:   "delete [uid]",
-	Short: "Delete a {{.Name}}",
-	Args:  cobra.ExactArgs(1),
+	Use:   "delete [uid...]",
+	Short: "Delete one or more {{.Name}} resources",
+	Long: `Deletes one or more {{.Name}} resources. 
+
+You can provide multiple UIDs separated by spaces to delete them all in a single command. 
+Each UID is processed one by one as an individual, atomic delete operation. If any deletion fails, the command will still attempt to delete the remaining UIDs and report the errors at the end.`,
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := getClient()
 		if err != nil {
@@ -564,11 +568,22 @@ var {{toLower .Name}}DeleteCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		if err := c.Delete{{.Name}}(ctx, args[0]); err != nil {
-			return fmt.Errorf("failed to delete {{.Name}}: %w", err)
+		var errs []error
+		for _, uid := range args {
+			if err := c.Delete{{.Name}}(ctx, uid); err != nil {
+				errs = append(errs, fmt.Errorf("failed to delete {{.Name}} %q: %w", uid, err))
+				continue
+			}
+			fmt.Printf("{{.Name}} %s deleted successfully\n", uid)
 		}
-
-		fmt.Printf("{{.Name}} %s deleted successfully\n", args[0])
+		
+		if len(errs) > 0 {
+			var errMsgs []string
+			for _, e := range errs {
+				errMsgs = append(errMsgs, e.Error())
+			}
+			return fmt.Errorf("encountered %d error(s) during deletion:\n%s", len(errs), strings.Join(errMsgs, "\n"))
+		}
 		return nil
 	},
 }

--- a/test/integration/runtime_test.go
+++ b/test/integration/runtime_test.go
@@ -505,6 +505,39 @@ func (s *RuntimeTestSuite) TestEntSQLiteReconciliationClientFlow() {
 	var nodesAfter []map[string]interface{}
 	s.Require().NoError(json.Unmarshal(nodeListAfter, &nodesAfter))
 	s.Require().Len(nodesAfter, 0, "node list should be empty after deletion")
+
+	// Check help text
+	helpOut, err := project.RunClientBinary(clientBinary, "node", "delete", "--help")
+	s.Require().NoError(err)
+	s.Require().Contains(string(helpOut), "delete [uid...]", "help text should show variadic uid support")
+
+	// Test bulk delete
+	// Create extra test nodes
+	bulkNode1Payload := `{"metadata":{"name":"bulk-node-1"},"spec":{"description":"bulk node 1"}}`
+	bulkNode1Out, err := project.RunClientBinary(clientBinary, "node", "create", "--spec", bulkNode1Payload, "--output", "json")
+	s.Require().NoError(err)
+	var createdBulkNode1 map[string]interface{}
+	s.Require().NoError(json.Unmarshal(bulkNode1Out, &createdBulkNode1))
+	bulkNode1UID := createdBulkNode1["metadata"].(map[string]interface{})["uid"].(string)
+
+	bulkNode2Payload := `{"metadata":{"name":"bulk-node-2"},"spec":{"description":"bulk node 2"}}`
+	bulkNode2Out, err := project.RunClientBinary(clientBinary, "node", "create", "--spec", bulkNode2Payload, "--output", "json")
+	s.Require().NoError(err)
+	var createdBulkNode2 map[string]interface{}
+	s.Require().NoError(json.Unmarshal(bulkNode2Out, &createdBulkNode2))
+	bulkNode2UID := createdBulkNode2["metadata"].(map[string]interface{})["uid"].(string)
+
+	// Delete valid and invalid IDs together
+	_, err = project.RunClientBinary(clientBinary, "node", "delete", bulkNode1UID, "invalid-uid", bulkNode2UID)
+	s.Require().Error(err, "bulk delete with invalid uid should return error")
+	s.Require().Contains(err.Error(), "invalid-uid", "error should mention the invalid uid")
+
+	// Verify valid nodes are deleted
+	bulkNodeListAfter, err := project.RunClientBinary(clientBinary, "node", "list", "--output", "json")
+	s.Require().NoError(err)
+	var bulkNodesAfter []map[string]interface{}
+	s.Require().NoError(json.Unmarshal(bulkNodeListAfter, &bulkNodesAfter))
+	s.Require().Len(bulkNodesAfter, 0, "all valid nodes should be deleted in bulk delete")
 }
 
 // TestValidationWithInlinedSpecFields verifies validation on the flattened envelope pattern


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] My code follows the style guidelines of this project.
- [ ] I have added/updated comments where needed.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] I have run `make test` (or equivalent) locally and all tests pass.
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email.
- [x] **REUSE Compliance**:
  - [x] Each new/modified source file has SPDX copyright and license headers.
  - [x] Any non-commentable files include a `<filename>.license` sidecar.
  - [x] All referenced licenses are present in the `LICENSES/` directory.

### Description

This PR adds bulk delete support to the generated CLI client by allowing the `delete` subcommand to accept one or more UIDs instead of exactly one.

It keeps single-UID delete backward compatible, attempts deletion for every provided UID, reports per-item failures, and returns an error at the end if any deletion fails.

Fixes #30

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---
