### PR TITLE
fix(template): use underscores for config keys/env vars, hyphens for flags

### DIFF
--- a/cmd/fabrica/init.go
+++ b/cmd/fabrica/init.go
@@ -59,6 +59,7 @@ type initOptions struct {
 // initial files (main.go, go.mod, README, etc.) with appropriate settings.
 type templateData struct {
 	ProjectName          string
+	EnvPrefix            string
 	ModulePath           string
 	Description          string
 	WithAuth             bool
@@ -449,6 +450,7 @@ func createProjectStructure(targetDir, projectName string, opts *initOptions) er
 	// Template data
 	data := templateData{
 		ProjectName:          projectName,
+		EnvPrefix:            envPrefix(projectName),
 		ModulePath:           opts.modulePath,
 		Description:          opts.description,
 		WithAuth:             opts.withAuth,
@@ -565,6 +567,26 @@ func createProjectStructure(targetDir, projectName string, opts *initOptions) er
 	}
 
 	return nil
+}
+
+// envPrefix converts a project name into a valid uppercase environment
+// variable prefix, replacing every non-alphanumeric character with an
+// underscore so "fru-tracker" yields "FRU_TRACKER" (read as FRU_TRACKER_*).
+// A plain strings.ToUpper is insufficient: it leaves hyphens in the prefix,
+// producing shell-hostile names like FRU-TRACKER_PORT.
+func envPrefix(projectName string) string {
+	upper := strings.ToUpper(projectName)
+	var b strings.Builder
+	b.Grow(len(upper))
+	for _, r := range upper {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // generateFromTemplate executes a named template and writes the result to a file.

--- a/cmd/fabrica/template_config_binding_test.go
+++ b/cmd/fabrica/template_config_binding_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 OpenCHAMI Contributors
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTemplate_InitMain_BindsHyphenatedFlagsToUnderscoreConfigKeys(t *testing.T) {
+	mainTmpl := mustReadFile(t, "pkg/codegen/templates/init/main.go.tmpl")
+
+	requiredMarkers := []string{
+		`"strings"`,
+		`"github.com/spf13/pflag"`,
+		"func bindFlagsWithUnderscoreKeys(flags *pflag.FlagSet) error",
+		`strings.ReplaceAll(flag.Name, "-", "_")`,
+		"viper.BindPFlag(key, flag)",
+		"bindFlagsWithUnderscoreKeys(serveCmd.Flags())",
+		"bindFlagsWithUnderscoreKeys(rootCmd.PersistentFlags())",
+		`viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))`,
+	}
+
+	for _, marker := range requiredMarkers {
+		if !strings.Contains(mainTmpl, marker) {
+			t.Fatalf("init/main.go.tmpl must contain %q", marker)
+		}
+	}
+
+	forbiddenMarkers := []string{
+		"viper.BindPFlags(serveCmd.Flags())",
+		"viper.BindPFlags(rootCmd.PersistentFlags())",
+	}
+
+	for _, marker := range forbiddenMarkers {
+		if strings.Contains(mainTmpl, marker) {
+			t.Fatalf("init/main.go.tmpl should not contain %q", marker)
+		}
+	}
+}
+
+func TestTemplate_InitMain_UsesUnderscoreMapstructureKeys(t *testing.T) {
+	mainTmpl := mustReadFile(t, "pkg/codegen/templates/init/main.go.tmpl")
+
+	if !strings.Contains(mainTmpl, "DatabaseURL string `mapstructure:\"database_url\"`") {
+		t.Fatal("init/main.go.tmpl should use underscore-based database_url mapstructure key")
+	}
+
+	if strings.Contains(mainTmpl, "mapstructure:\"database-url\"") {
+		t.Fatal("init/main.go.tmpl should not use hyphen-based database-url mapstructure key")
+	}
+
+	if !strings.Contains(mainTmpl, `serveCmd.Flags().String("database-url"`) {
+		t.Fatal("init/main.go.tmpl should keep the database-url CLI flag hyphenated")
+	}
+}
+
+func TestTemplate_InitGoMod_IncludesPFlagDependency(t *testing.T) {
+	goModTmpl := mustReadFile(t, "pkg/codegen/templates/init/go.mod.tmpl")
+
+	if !strings.Contains(goModTmpl, "github.com/spf13/pflag") {
+		t.Fatal("init/go.mod.tmpl should include pflag because generated server imports it directly")
+	}
+}

--- a/pkg/codegen/templates/init/env.tmpl
+++ b/pkg/codegen/templates/init/env.tmpl
@@ -8,9 +8,34 @@ SPDX-License-Identifier: MIT
 # Generated: {{.GeneratedAt}}
 #
 # Copy to .env and edit as needed.
+#
+# Variable naming in this file follows two conventions:
+#   - {{.EnvPrefix}}_* : per-service settings for "{{.ProjectName}}". The prefix
+#     is unique per service, so multiple services can share one .env / one
+#     docker-compose environment without their settings colliding.
+#   - TOKENSMITH_*      : shared TokenSmith deployment settings. These are read
+#     directly (unprefixed) and are intentionally common across every service
+#     that points at the same TokenSmith instance.
 
+# --- {{.ProjectName}} server ({{.EnvPrefix}}_*) ---
+# Uncomment to override the built-in defaults. CLI flags use hyphens
+# (e.g. --read-timeout); env vars and config-file keys use underscores.
+# {{.EnvPrefix}}_PORT=8080
+# {{.EnvPrefix}}_HOST=0.0.0.0
+# {{.EnvPrefix}}_READ_TIMEOUT=15
+# {{.EnvPrefix}}_WRITE_TIMEOUT=15
+# {{.EnvPrefix}}_IDLE_TIMEOUT=60
+# {{.EnvPrefix}}_DEBUG=false
+{{- if .WithStorage }}
+{{- if eq .StorageType "file" }}
+# {{.EnvPrefix}}_DATA_DIR=./data
+{{- else if eq .StorageType "ent" }}
+# {{.EnvPrefix}}_DATABASE_URL=
+{{- end }}
+{{- end }}
 {{- if .WithAuth }}
-# --- TokenSmith AuthN/AuthZ ---
+
+# --- TokenSmith AuthN/AuthZ (shared, unprefixed) ---
 
 # AuthN (JWT validation)
 # Required when security.authn.enabled=true

--- a/pkg/codegen/templates/init/go.mod.tmpl
+++ b/pkg/codegen/templates/init/go.mod.tmpl
@@ -14,6 +14,7 @@ go {{.GoVersion}}
 require (
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	{{- if .WithAuth }}
 	{{.TokenSmithModulePath}} {{.TokenSmithVersion}}

--- a/pkg/codegen/templates/init/main.go.tmpl
+++ b/pkg/codegen/templates/init/main.go.tmpl
@@ -20,10 +20,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -53,7 +55,7 @@ type Config struct {
 	{{if eq .StorageType "file"}}
 	DataDir string `mapstructure:"data_dir"`
 	{{else if eq .StorageType "ent"}}
-	DatabaseURL string `mapstructure:"database-url"`
+	DatabaseURL string `mapstructure:"database_url"`
 	{{end}}
 	{{end}}
 
@@ -125,6 +127,21 @@ var serveCmd = &cobra.Command{
 	RunE:  runServer,
 }
 
+func bindFlagsWithUnderscoreKeys(flags *pflag.FlagSet) error {
+	var bindErr error
+
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if bindErr != nil {
+			return
+		}
+
+		key := strings.ReplaceAll(flag.Name, "-", "_")
+		bindErr = viper.BindPFlag(key, flag)
+	})
+
+	return bindErr
+}
+
 func init() {
 	cobra.OnInitialize(initConfig)
 
@@ -158,8 +175,12 @@ func init() {
 	{{end}}
 
 	// Bind flags to viper
-	viper.BindPFlags(serveCmd.Flags())
-	viper.BindPFlags(rootCmd.PersistentFlags())
+	if err := bindFlagsWithUnderscoreKeys(serveCmd.Flags()); err != nil {
+		panic(fmt.Errorf("failed to bind serve flags: %w", err))
+	}
+	if err := bindFlagsWithUnderscoreKeys(rootCmd.PersistentFlags()); err != nil {
+		panic(fmt.Errorf("failed to bind root flags: %w", err))
+	}
 
 	// Add subcommands
 	rootCmd.AddCommand(serveCmd)
@@ -191,6 +212,7 @@ func initConfig() {
 
 	// Environment variables
 	viper.SetEnvPrefix("{{toUpper .ProjectName}}")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	// Read config file if it exists

--- a/pkg/codegen/templates/init/main.go.tmpl
+++ b/pkg/codegen/templates/init/main.go.tmpl
@@ -211,7 +211,7 @@ func initConfig() {
 	}
 
 	// Environment variables
-	viper.SetEnvPrefix("{{toUpper .ProjectName}}")
+	viper.SetEnvPrefix("{{.EnvPrefix}}")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/pkg/codegen/templates/init/readme.md.tmpl
+++ b/pkg/codegen/templates/init/readme.md.tmpl
@@ -23,7 +23,7 @@ Generated: {{.GeneratedAt}}
 
 The server supports configuration via:
 - Command line flags
-- Environment variables ({{toUpper .ProjectName}}_*)
+- Environment variables ({{.EnvPrefix}}_*)
 - Configuration file (~/.{{.ProjectName}}.yaml)
 
 ## Features


### PR DESCRIPTION
### Description

A conflict in Viper naming schemas was causing a bug where a config file using underscore-separated config keys (which is correct according to the documentation) would get overridden by the default values, which use hyphen-separated keys. This could be fixed by using hyphen-separated keys in the config file, but this is neither idiomatic for YAML keys nor consistent with the config documentation.

This is due to ambiguity in the way Viper config key aliases are used. The config struct uses underscores for mapstructure tags and flags use hyphens. Flags are aliased to config keys via
`viper.RegisterAlias("config_key", "config-key")`, but this causes the unintentional side effect of hyphen-separated values being able to override underscore-separated values in an ambiguous way, such as the default values not being overridden by config file values.

The intended behavior is strictly that:

- CLI flags only use hyphen separation
- config file and environment variable keys use underscore separation

Therefore, this change modifies the server main.go that gets generated during `fabrica init` to remove the viper alias registration and add a `bindFlagsWithUnderscoreKeys()` helper that dynamically binds hyphen-separated flags to underscore-separated config values. This ensures the rules stated above.

Since Fabrica does not regenerate the server's main.go, this change must be implemented in each service that has already been generated with Fabrica.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
