### PR TITLE
feat: add POSIX installer and validation scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,12 @@ jobs:
         with:
           go-version: '1.26.5'
 
+      - name: Validate POSIX installer
+        run: |
+          sh -n scripts/install.sh
+          sh -n scripts/test-install.sh
+          sh scripts/test-install.sh
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ examples/rack-inventory/
 examples/sensor-monitor/
 
 graphify-out/
+.omo/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,12 +124,20 @@ release:
   draft: false
   prerelease: auto
   mode: append
+  extra_files:
+    - glob: ./scripts/install.sh
+      name_template: install.sh
   header: |
     ## Fabrica {{ .Version }}
 
     **Release Date:** {{ .Date }}
 
     ### Installation
+
+    #### Installer (Linux and macOS)
+    ```bash
+    curl -fsSL https://github.com/openchami/fabrica/releases/latest/download/install.sh | sh
+    ```
 
     #### Binaries
     Download the appropriate binary for your platform from the assets below.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-.PHONY: help build test test-integration test-all lint clean install install-release run docker-build docker-run
+.PHONY: help build test test-install-script test-integration test-all lint clean install install-release run docker-build docker-run
 
 # Variables
 BINARY_NAME=fabrica
@@ -13,7 +13,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
-LATEST_RELEASE ?= v0.4.7
+RELEASE_VERSION ?= latest
 ACT_GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod | cut -d. -f1,2)
 ACT_LOCAL_GO_VERSION ?= 1.25
 ACT_DOCKER_HOST ?= $(shell docker context inspect $${DOCKER_CONTEXT:-$$(docker context show 2>/dev/null)} 2>/dev/null | awk -F'"' '/"Host":/ {print $$4; exit}')
@@ -37,10 +37,13 @@ build: ## Build the application
 test: ## Run tests
 	$(GO) test $(GOFLAGS) -race -coverprofile=coverage.out -covermode=atomic $$(go list ./... 2>/dev/null | grep -v /examples/)
 
+test-install-script: ## Run deterministic offline tests for the POSIX release installer
+	sh scripts/test-install.sh
+
 test-integration: ## Run integration tests
 	cd test/integration && $(GO) test $(GOFLAGS) ./...
 
-test-all: test test-integration ## Run all tests (unit + integration)
+test-all: test test-install-script test-integration ## Run all tests (unit + installer + integration)
 
 test-coverage: test ## Run tests with coverage report
 	$(GO) tool cover -html=coverage.out -o coverage.html
@@ -60,8 +63,8 @@ install: ## Install dependencies
 	$(GO) mod download
 	$(GO) mod verify
 
-install-release: ## Install latest released Fabrica CLI
-	$(GO) install github.com/openchami/fabrica/cmd/fabrica@$(LATEST_RELEASE)
+install-release: ## Install Fabrica CLI at @latest (override with RELEASE_VERSION=vX.Y.Z)
+	$(GO) install github.com/openchami/fabrica/cmd/fabrica@$(RELEASE_VERSION)
 
 tidy: ## Tidy go.mod
 	$(GO) mod tidy
@@ -195,6 +198,6 @@ act-all: ## Run all testable workflows locally (build, test, lint, reuse, vuln)
 	@echo "\n=== Vulnerability Check Workflow ==="
 	$(call run_act,push -W .github/workflows/govulncheck.yaml --container-architecture linux/amd64 -j govulncheck) || true
 
-all: clean install lint test build ## Run all checks and build
+all: clean install lint test test-install-script build ## Run all checks and build
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -56,22 +56,43 @@ Fabrica is a powerful code generation tool that accelerates API development by t
 
 ## 📦 Installation
 
-### Latest Release (v0.4.9)
+### Latest stable release
 
-**macOS/Linux:**
+Install on Linux or macOS with the POSIX installer:
+
 ```bash
-# Direct download and install
-curl -L https://github.com/openchami/fabrica/releases/download/v0.4.9/fabrica-$(uname -s)-$(uname -m) -o fabrica
-chmod +x fabrica
-sudo mv fabrica /usr/local/bin/
+curl -fsSL https://github.com/openchami/fabrica/releases/latest/download/install.sh | sh
+```
 
-# Verify installation
+The default destination is `${XDG_BIN_HOME:-$HOME/.local/bin}`. The installer is non-interactive, never invokes `sudo`, and does not modify shell startup files. To inspect it before running:
+
+```bash
+curl -fsSLo install.sh https://github.com/openchami/fabrica/releases/latest/download/install.sh
+less install.sh
+sh install.sh
+rm install.sh
+```
+
+Select a release (with or without a leading `v`) or destination through environment variables:
+
+```bash
+curl -fsSL https://github.com/openchami/fabrica/releases/latest/download/install.sh \
+  | FABRICA_VERSION=v1.2.3 FABRICA_INSTALL_DIR="$HOME/bin" sh
+
+XDG_BIN_HOME="$HOME/.local/bin" sh install.sh
+```
+
+The installer downloads the matching GoReleaser archive and `checksums.txt`, then verifies the archive's SHA-256 checksum before extraction. For higher assurance, use the inspect-before-run flow and review the release assets on GitHub.
+
+Verify the installation:
+
+```bash
 fabrica version
 ```
 
 **Using Go:**
 ```bash
-go install github.com/openchami/fabrica/cmd/fabrica@v0.4.9
+go install github.com/openchami/fabrica/cmd/fabrica@latest
 ```
 
 ### Development Version
@@ -347,7 +368,7 @@ We welcome contributions from the community! Here's how to get involved:
 
 ## 🏷️ Releases & Roadmap
 
-**Current Version:** [v0.4.9](https://github.com/openchami/fabrica/releases/tag/v0.4.9)
+**Current Version:** See the [latest Fabrica release](https://github.com/openchami/fabrica/releases/latest).
 
 **📅 Recent Updates:**
 - ✅ Prometheus metrics support and generated instrumentation

--- a/cmd/fabrica/generate.go
+++ b/cmd/fabrica/generate.go
@@ -182,6 +182,13 @@ Examples:
 				}
 			}
 
+			// Preflight: Check module compatibility before any generated-file mutations.
+			if !force {
+				if err := checkModuleCompatibility(version, debug); err != nil {
+					return err // Error message already formatted with actionable guidance
+				}
+			}
+
 			// Auto-generate registration file
 			fmt.Println()
 			fmt.Println("📝 Registration file not found, creating it...")
@@ -194,13 +201,6 @@ Examples:
 			// 1. Generated code may introduce new imports
 			// 2. The user should run it after generation completes
 			// This avoids circular dependency issues with code generators like Ent
-
-			// Preflight: Check module compatibility before code generation
-			if !force {
-				if err := checkModuleCompatibility(version, debug); err != nil {
-					return err // Error message already formatted with actionable guidance
-				}
-			}
 
 			// Generate server code (handlers, storage, openapi)
 			if all || handlers || storage || openapi {
@@ -302,7 +302,7 @@ func checkModuleCompatibility(cliVersion string, debug bool) error {
 
 	projectMod := projectVersion[0]
 	projectVer := projectVersion[1]
-	normalizedCLI := normalizeVersionForCompatibilityCheck(cliVersion)
+	normalizedCLI := normalizeCLIVersionForCompatibilityCheck(cliVersion)
 	normalizedProject := normalizeVersionForCompatibilityCheck(projectVer)
 
 	if debug {
@@ -314,7 +314,7 @@ func checkModuleCompatibility(cliVersion string, debug bool) error {
 	// Simple version comparison: if CLI is "dev" or versions are exactly equal, allow
 	// Otherwise, if they differ and neither is "dev", warn the user
 	// nolint:revive,staticcheck
-	if normalizedCLI != "dev" && normalizedProject != normalizedCLI && normalizedProject != "" {
+	if !moduleVersionsCompatible(cliVersion, projectVer) {
 		return fmt.Errorf(`
 ❌ Module version mismatch detected:
 
@@ -344,14 +344,58 @@ Or use --force to skip this check and proceed at your own risk.
 	return nil
 }
 
+func moduleVersionsCompatible(cliVersion, projectVersion string) bool {
+	normalizedCLI := normalizeCLIVersionForCompatibilityCheck(cliVersion)
+	normalizedProject := normalizeVersionForCompatibilityCheck(projectVersion)
+	return normalizedCLI == "dev" || normalizedProject == "" || normalizedProject == normalizedCLI
+}
+
+func normalizeCLIVersionForCompatibilityCheck(version string) string {
+	normalized := normalizeVersionForCompatibilityCheck(version)
+	parts := strings.Split(normalized, "-")
+	end := len(parts)
+	dirty := end > 1 && parts[end-1] == "dirty"
+	if dirty {
+		end--
+	}
+
+	if end >= 3 && strings.HasPrefix(parts[end-1], "g") {
+		count := parts[end-2]
+		if count == "" || count[0] < '1' || count[0] > '9' || parts[end-3] == "" {
+			return normalized
+		}
+		for index := 1; index < len(count); index++ {
+			if count[index] < '0' || count[index] > '9' {
+				return normalized
+			}
+		}
+
+		hash := strings.TrimPrefix(parts[end-1], "g")
+		if hash == "" {
+			return normalized
+		}
+		for _, digit := range hash {
+			if (digit < '0' || digit > '9') && (digit < 'a' || digit > 'f') && (digit < 'A' || digit > 'F') {
+				return normalized
+			}
+		}
+
+		return strings.Join(parts[:end-2], "-")
+	}
+
+	// Preserve the Makefile's git describe --tags --always --dirty exact-tag output.
+	if dirty {
+		return strings.Join(parts[:end], "-")
+	}
+	return normalized
+}
+
 func normalizeVersionForCompatibilityCheck(version string) string {
+	version = strings.TrimSpace(version)
 	if version == "" {
 		return version
 	}
-	if dash := strings.Index(version, "-"); dash > 0 {
-		return version[:dash]
-	}
-	return version
+	return strings.TrimPrefix(version, "v")
 }
 
 func resolveGenerateFabricaSource(flagValue string) (string, error) {

--- a/cmd/fabrica/generate_preflight_test.go
+++ b/cmd/fabrica/generate_preflight_test.go
@@ -5,14 +5,189 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestCheckModuleCompatibility_ExactVersionMatch(t *testing.T) { //nolint:revive
-	// Same versions should not error (but we can't easily unit test the full
-	// function without mocking exec.Command, so this test documents the behavior)
-	// The real test is in integration tests where we verify the actual go list call
+func TestNormalizeVersionForCompatibilityCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "CLI release matches prefixed module release", version: "0.4.9", want: "0.4.9"},
+		{name: "prefixed CLI release matches module release", version: "v0.4.9", want: "0.4.9"},
+		{name: "trims surrounding whitespace", version: "  v0.4.9  ", want: "0.4.9"},
+		{name: "preserves dev sentinel", version: "dev", want: "dev"},
+		{name: "preserves empty version", version: "", want: ""},
+		{name: "preserves prerelease suffix", version: "v0.4.9-rc.1", want: "0.4.9-rc.1"},
+		{name: "preserves pseudo-version suffix", version: "v0.4.9-0.20260720000000-abcdef123456", want: "0.4.9-0.20260720000000-abcdef123456"},
+		{name: "preserves git describe suffix generically", version: "v0.4.9-6-g88dc4ca-dirty", want: "0.4.9-6-g88dc4ca-dirty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			version := tt.version
+
+			// When
+			got := normalizeVersionForCompatibilityCheck(version)
+
+			// Then
+			if got != tt.want {
+				t.Fatalf("normalizeVersionForCompatibilityCheck(%q) = %q, want %q", version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCLIVersionForCompatibilityCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "exact release tag dirty", version: "v0.4.9-dirty", want: "0.4.9"},
+		{name: "exact prerelease tag dirty", version: "v0.4.9-rc.1-dirty", want: "0.4.9-rc.1"},
+		{name: "signed positive count remains exact", version: "v0.4.9-+6-g88dc4ca", want: "0.4.9-+6-g88dc4ca"},
+		{name: "signed negative count remains exact", version: "v0.4.9--6-g88dc4ca", want: "0.4.9--6-g88dc4ca"},
+		{name: "zero-padded count remains exact", version: "v0.4.9-06-g88dc4ca", want: "0.4.9-06-g88dc4ca"},
+		{name: "zero count remains exact", version: "v0.4.9-0-g88dc4ca", want: "0.4.9-0-g88dc4ca"},
+		{name: "nonnumeric count remains exact", version: "v0.4.9-six-g88dc4ca", want: "0.4.9-six-g88dc4ca"},
+		{name: "nonhex hash remains exact", version: "v0.4.9-6-gnothex", want: "0.4.9-6-gnothex"},
+		{name: "empty hash remains exact", version: "v0.4.9-6-g", want: "0.4.9-6-g"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			version := tt.version
+
+			// When
+			got := normalizeCLIVersionForCompatibilityCheck(version)
+
+			// Then
+			if got != tt.want {
+				t.Fatalf("normalizeCLIVersionForCompatibilityCheck(%q) = %q, want %q", version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModuleVersionsCompatible(t *testing.T) {
+	tests := []struct {
+		name           string
+		cliVersion     string
+		projectVersion string
+		want           bool
+	}{
+		{name: "exact release versions", cliVersion: "0.4.9", projectVersion: "0.4.9", want: true},
+		{name: "CLI release and prefixed module release", cliVersion: "0.4.9", projectVersion: "v0.4.9", want: true},
+		{name: "development CLI", cliVersion: "dev", projectVersion: "v9.9.9", want: true},
+		{name: "unknown project version", cliVersion: "0.4.9", projectVersion: "", want: true},
+		{name: "different release versions", cliVersion: "0.4.9", projectVersion: "v0.5.0", want: false},
+		{name: "release differs from prerelease", cliVersion: "0.4.9", projectVersion: "v0.4.9-rc.1", want: false},
+		{name: "release differs from pseudo-version", cliVersion: "0.4.9", projectVersion: "v0.4.9-0.20260720000000-abcdef123456", want: false},
+		{name: "identical prerelease accepts optional prefix", cliVersion: "0.4.9-rc.1", projectVersion: "v0.4.9-rc.1", want: true},
+		{name: "identical pseudo-version accepts optional prefix", cliVersion: "0.4.9-0.20260720000000-abcdef123456", projectVersion: "v0.4.9-0.20260720000000-abcdef123456", want: true},
+		{name: "exact release tag dirty CLI matches release module", cliVersion: "v0.4.9-dirty", projectVersion: "v0.4.9", want: true},
+		{name: "exact prerelease tag dirty CLI matches prerelease module", cliVersion: "v0.4.9-rc.1-dirty", projectVersion: "v0.4.9-rc.1", want: true},
+		{name: "git describe CLI matches release tag", cliVersion: "v0.4.9-6-g88dc4ca-dirty", projectVersion: "v0.4.9", want: true},
+		{name: "git describe CLI matches prerelease tag", cliVersion: "v0.4.9-rc.1-6-g88dc4ca", projectVersion: "v0.4.9-rc.1", want: true},
+		{name: "identical non-git dash suffix accepts optional prefix", cliVersion: "0.4.9-custom", projectVersion: "v0.4.9-custom", want: true},
+		{name: "different non-git dash suffixes remain distinct", cliVersion: "0.4.9-custom", projectVersion: "v0.4.9-other", want: false},
+		{name: "zero git commit count remains distinct", cliVersion: "v0.4.9-0-g88dc4ca", projectVersion: "v0.4.9", want: false},
+		{name: "nonhex git hash remains distinct", cliVersion: "v0.4.9-6-gnothex", projectVersion: "v0.4.9", want: false},
+		{name: "empty git hash remains distinct", cliVersion: "v0.4.9-6-g", projectVersion: "v0.4.9", want: false},
+		{name: "module dirty suffix remains distinct from release CLI", cliVersion: "0.4.9", projectVersion: "v0.4.9-dirty", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			cliVersion := tt.cliVersion
+			projectVersion := tt.projectVersion
+
+			// When
+			got := moduleVersionsCompatible(cliVersion, projectVersion)
+
+			// Then
+			if got != tt.want {
+				t.Fatalf("moduleVersionsCompatible(%q, %q) = %t, want %t", cliVersion, projectVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateCommand_ModulePreflightRunsBeforeRegistrationMutation(t *testing.T) {
+	// Given
+	projectDir := t.TempDir()
+	resourcesDir := filepath.Join(projectDir, "pkg", "resources")
+	if err := os.MkdirAll(resourcesDir, 0o755); err != nil {
+		t.Fatalf("create resources directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "go.mod"), []byte("module example.com/preflight\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	fabricaConfig := "project:\n  name: preflight\n  module: example.com/preflight\nfeatures:\n  storage:\n    enabled: true\n    type: file\n"
+	if err := os.WriteFile(filepath.Join(projectDir, ".fabrica.yaml"), []byte(fabricaConfig), 0o644); err != nil {
+		t.Fatalf("write Fabrica config: %v", err)
+	}
+	apisConfig := "groups:\n  - name: test.example\n    storageVersion: v1\n    versions: [v1]\n    resources: [Widget]\n"
+	if err := os.WriteFile(filepath.Join(projectDir, "apis.yaml"), []byte(apisConfig), 0o644); err != nil {
+		t.Fatalf("write APIs config: %v", err)
+	}
+	resourceSource := "package resources\n\nimport \"github.com/openchami/fabrica/pkg/resource\"\n\ntype Widget struct { resource.Resource }\n"
+	if err := os.WriteFile(filepath.Join(resourcesDir, "widget.go"), []byte(resourceSource), 0o644); err != nil {
+		t.Fatalf("write resource: %v", err)
+	}
+	registrationPath := filepath.Join(resourcesDir, "register_generated.go")
+	originalRegistration := []byte("package resources\n\nconst preflightSentinel = \"unchanged\"\n")
+	if err := os.WriteFile(registrationPath, originalRegistration, 0o644); err != nil {
+		t.Fatalf("write registration sentinel: %v", err)
+	}
+
+	fakeBinDir := t.TempDir()
+	fakeGo := filepath.Join(fakeBinDir, "go")
+	if err := os.WriteFile(fakeGo, []byte("#!/bin/sh\nprintf '%s\\n' 'github.com/openchami/fabrica v9.9.9'\n"), 0o755); err != nil {
+		t.Fatalf("write fake go command: %v", err)
+	}
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("change to project directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+	originalVersion := version
+	version = "0.4.9"
+	t.Cleanup(func() { version = originalVersion })
+	cmd := newGenerateCommand()
+	cmd.SetArgs([]string{})
+
+	// When
+	err = cmd.Execute()
+
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "Module version mismatch detected") {
+		t.Fatalf("generate error = %v, want module version mismatch", err)
+	}
+	registration, err := os.ReadFile(registrationPath)
+	if err != nil {
+		t.Fatalf("read registration sentinel: %v", err)
+	}
+	if string(registration) != string(originalRegistration) {
+		t.Fatalf("registration file mutated before module preflight:\n%s", registration)
+	}
 }
 
 func TestCheckModuleCompatibility_ErrorMessage_HasActionableGuidance(t *testing.T) {

--- a/cmd/fabrica/main.go
+++ b/cmd/fabrica/main.go
@@ -67,6 +67,13 @@ func versionString() string {
 func main() {
 	mcp.Version = version
 
+	if err := newRootCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func newRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "fabrica",
 		Short: "Fabrica - Resource-based REST API framework",
@@ -79,10 +86,11 @@ The CLI provides commands for:
   - Interactive wizards for guided setup
   - Example generation with progressive disclosure
   - Documentation generation`,
-		Version: versionString(),
+		Version:       versionString(),
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
-	// Add commands
 	rootCmd.AddCommand(newInitCommand())
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newGenerateCommand())
@@ -91,10 +99,7 @@ The CLI provides commands for:
 	rootCmd.AddCommand(mcp.NewCommand())
 	rootCmd.AddCommand(newVersionCommand())
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	return rootCmd
 }
 
 func newVersionCommand() *cobra.Command {

--- a/cmd/fabrica/main_version_test.go
+++ b/cmd/fabrica/main_version_test.go
@@ -94,6 +94,23 @@ func TestResolveVersionInfo_PreservesLdflagsValues(t *testing.T) {
 	}
 }
 
+func TestNewRootCommand_SilencesFrameworkErrorOutput(t *testing.T) {
+	// Given
+	cmd := newRootCommand()
+
+	// When
+	silenceErrors := cmd.SilenceErrors
+	silenceUsage := cmd.SilenceUsage
+
+	// Then
+	if !silenceErrors {
+		t.Fatal("expected root command to silence Cobra error rendering")
+	}
+	if !silenceUsage {
+		t.Fatal("expected root command to silence Cobra usage rendering on errors")
+	}
+}
+
 func TestBuiltCLI_VersionCommandRuns(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,10 +35,8 @@ The `fabrica` CLI provides commands for initializing projects, adding resources,
 # Latest release
 go install github.com/openchami/fabrica/cmd/fabrica@latest
 
-# Or download binary
-curl -L https://github.com/openchami/fabrica/releases/latest/download/fabrica-$(uname -s)-$(uname -m) -o fabrica
-chmod +x fabrica
-sudo mv fabrica /usr/local/bin/
+# Or use the checksum-verifying release installer
+curl -fsSL https://github.com/openchami/fabrica/releases/latest/download/install.sh | sh
 ```
 
 **Quick Start:**

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -42,6 +42,7 @@ When you push a tag matching `v*.*.*`, GitHub Actions automatically:
 1. ✅ Builds binaries for:
    - Linux AMD64
    - Linux ARM64
+   - Darwin (macOS) AMD64
    - Darwin (macOS) ARM64
 
 2. ✅ Creates Docker images for:
@@ -54,8 +55,12 @@ When you push a tag matching `v*.*.*`, GitHub Actions automatically:
    - `ghcr.io/openchami/fabrica:latest`
 
 4. ✅ Creates GitHub Release with:
-   - Binaries for all platforms
-   - Checksums
+   - `fabrica_<version>_linux_x86_64.tar.gz`
+   - `fabrica_<version>_linux_arm64.tar.gz`
+   - `fabrica_<version>_darwin_x86_64.tar.gz`
+   - `fabrica_<version>_darwin_arm64.tar.gz`
+   - `checksums.txt`
+   - The POSIX installer as `install.sh`
    - Auto-generated changelog
 
 ### 4. Verify the Release
@@ -87,6 +92,24 @@ tar xzf fabrica_1.0.0_darwin_arm64.tar.gz
 ./fabrica version
 ```
 
+#### Test the Installer Asset
+
+Download the published installer, syntax-check it, and install the tagged release into an isolated temporary directory:
+
+```bash
+VERSION=1.0.0
+VERIFY_DIR=$(mktemp -d)
+curl -fsSLo "$VERIFY_DIR/install.sh" \
+  "https://github.com/openchami/fabrica/releases/download/v${VERSION}/install.sh"
+sh -n "$VERIFY_DIR/install.sh"
+FABRICA_VERSION="$VERSION" FABRICA_INSTALL_DIR="$VERIFY_DIR/bin" \
+  sh "$VERIFY_DIR/install.sh"
+"$VERIFY_DIR/bin/fabrica" version
+rm -rf "$VERIFY_DIR"
+```
+
+This verifies that `install.sh` is attached to the release, resolves the documented archive name, validates `checksums.txt`, and can install without writing to the user's normal binary directories.
+
 #### Test Docker Images
 
 ```bash
@@ -107,6 +130,7 @@ The release process is configured in:
   - Binary builds for multiple platforms
   - Docker image builds
   - Archive creation
+  - Installer publication as the `install.sh` release asset
   - Changelog generation
 
 - **`.github/workflows/release.yaml`** - GitHub Actions workflow
@@ -127,6 +151,7 @@ The release process is configured in:
 |----------|-------------|---------|
 | Linux | AMD64 | `fabrica_*_linux_x86_64.tar.gz` |
 | Linux | ARM64 | `fabrica_*_linux_arm64.tar.gz` |
+| macOS | AMD64 | `fabrica_*_darwin_x86_64.tar.gz` |
 | macOS | ARM64 | `fabrica_*_darwin_arm64.tar.gz` |
 
 ### Docker Images
@@ -191,10 +216,11 @@ goreleaser release --clean
 
 After a successful release:
 
-1. ✅ Update documentation if needed
-2. ✅ Announce the release (Slack, Discord, etc.)
-3. ✅ Close related issues/PRs
-4. ✅ Update project roadmap
+1. ✅ Run the isolated installer verification above against the published `install.sh` asset
+2. ✅ Update documentation if needed
+3. ✅ Announce the release (Slack, Discord, etc.)
+4. ✅ Close related issues/PRs
+5. ✅ Update project roadmap
 
 ## Release Confidence Checklist
 
@@ -204,6 +230,7 @@ Before tagging a release, ensure the following readiness criteria are met:
 
 - [ ] **All integration tests pass** locally: `go test -v -timeout 10m ./test/integration`
 - [ ] **CI workflows pass** on main branch (lint, regression tests, govulncheck, REUSE)
+- [ ] **Offline installer tests pass** locally: `make test-install-script`
 - [ ] **CHANGELOG.md** is updated with all changes for this release
 - [ ] **Module compatibility checks** are working (preflight validation prevents version mismatches)
 - [ ] **Auth-enabled projects** generate and compile successfully
@@ -212,7 +239,7 @@ Before tagging a release, ensure the following readiness criteria are met:
 
 - [ ] **Previous version → current version upgrade** is tested:
   - Generate project with previous Fabrica version (e.g., v0.3.1)
-  - Run `fabrica generate` with current CLI version (v0.4.9)
+  - Run `fabrica generate` with the release candidate CLI version
   - Verify generated code compiles and basic operations work
 
 ### Binary Smoke Testing

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,177 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 OpenCHAMI Contributors
+#
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+repository="openchami/fabrica"
+github_url="https://github.com/$repository"
+api_url="https://api.github.com/repos/$repository"
+install_dir=${FABRICA_INSTALL_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}
+tmp_dir=
+staged_file=
+
+fail() {
+    printf 'fabrica installer: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$staged_file" ]; then
+        rm -f "$staged_file"
+    fi
+    if [ -n "$tmp_dir" ]; then
+        rm -rf "$tmp_dir"
+    fi
+}
+
+trap cleanup EXIT HUP INT TERM
+
+for command_name in uname mktemp tar awk grep cp chmod mv rm mkdir ls; do
+    command -v "$command_name" >/dev/null 2>&1 ||
+        fail "required command '$command_name' was not found"
+done
+
+if command -v curl >/dev/null 2>&1; then
+    download() {
+        url=$1
+        output=$2
+        curl -fsSL --retry 3 --output "$output" "$url" ||
+            fail "could not download $url; check your network connection and GitHub availability"
+    }
+elif command -v wget >/dev/null 2>&1; then
+    download() {
+        url=$1
+        output=$2
+        wget -q -O "$output" "$url" ||
+            fail "could not download $url; check your network connection and GitHub availability"
+    }
+else
+    fail "curl or wget is required to download Fabrica"
+fi
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fabrica-install.XXXXXX") ||
+    fail "could not create a temporary directory"
+
+if [ -n "${FABRICA_VERSION:-}" ]; then
+    version=$FABRICA_VERSION
+else
+    release_json="$tmp_dir/latest-release.json"
+    download "$api_url/releases/latest" "$release_json"
+    version=$(awk '
+        match($0, /"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"/) {
+            value = substr($0, RSTART, RLENGTH)
+            sub(/^.*"tag_name"[[:space:]]*:[[:space:]]*"/, "", value)
+            sub(/"$/, "", value)
+            print value
+            exit
+        }
+    ' "$release_json")
+    [ -n "$version" ] ||
+        fail "GitHub's latest stable release response did not contain a version"
+fi
+
+case "$version" in
+    v*) version=${version#v} ;;
+esac
+
+printf '%s\n' "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$' >/dev/null 2>&1 ||
+    fail "invalid FABRICA_VERSION '$version'; expected semantic version such as 1.2.3 or v1.2.3"
+
+uname_os=$(uname -s) || fail "could not determine the operating system"
+case "$uname_os" in
+    Linux) target_os=linux ;;
+    Darwin) target_os=darwin ;;
+    *) fail "unsupported operating system '$uname_os'; supported systems are Linux and Darwin" ;;
+esac
+
+uname_arch=$(uname -m) || fail "could not determine the machine architecture"
+if [ "$target_os" = darwin ] && [ "$uname_arch" = x86_64 ] && command -v sysctl >/dev/null 2>&1; then
+    if [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || printf '0')" = 1 ]; then
+        uname_arch=arm64
+    fi
+fi
+
+case "$uname_arch" in
+    x86_64|amd64) target_arch=x86_64 ;;
+    arm64|aarch64) target_arch=arm64 ;;
+    *) fail "unsupported architecture '$uname_arch'; supported architectures are x86_64 and arm64" ;;
+esac
+
+archive="fabrica_${version}_${target_os}_${target_arch}.tar.gz"
+release_url="$github_url/releases/download/v${version}"
+archive_path="$tmp_dir/$archive"
+checksums_path="$tmp_dir/checksums.txt"
+
+download "$release_url/$archive" "$archive_path"
+download "$release_url/checksums.txt" "$checksums_path"
+
+expected_checksum=$(awk -v target="$archive" '
+    $2 == target {
+        checksum = $1
+        matches++
+    }
+    END {
+        if (matches != 1) exit 1
+        print checksum
+    }
+' "$checksums_path") ||
+    fail "checksums.txt must contain exactly one entry for $archive"
+
+case "$expected_checksum" in
+    *[!0-9A-Fa-f]*|'') fail "invalid SHA-256 checksum entry for $archive" ;;
+esac
+[ "${#expected_checksum}" -eq 64 ] || fail "invalid SHA-256 checksum entry for $archive"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    actual_checksum=$(sha256sum "$archive_path" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    actual_checksum=$(shasum -a 256 "$archive_path" | awk '{print $1}')
+else
+    fail "sha256sum or shasum is required to verify the downloaded archive"
+fi
+
+[ "$actual_checksum" = "$expected_checksum" ] ||
+    fail "checksum verification failed for $archive; the archive was not installed"
+
+extract_dir="$tmp_dir/extract"
+mkdir "$extract_dir" || fail "could not prepare the temporary extraction directory"
+tar -xzf "$archive_path" -C "$extract_dir" fabrica ||
+    fail "could not extract the fabrica binary from $archive"
+
+binary="$extract_dir/fabrica"
+[ -f "$binary" ] || fail "the archive did not contain a regular fabrica file"
+case "$(ls -ld "$binary")" in
+    -*) ;;
+    *) fail "the fabrica archive entry is not a regular file" ;;
+esac
+chmod 0755 "$binary" || fail "could not mark the fabrica binary executable"
+[ -x "$binary" ] || fail "the extracted fabrica file is not executable"
+
+if [ ! -d "$install_dir" ]; then
+    mkdir -p "$install_dir" 2>/dev/null ||
+        fail "cannot create install directory '$install_dir'; choose a writable directory with FABRICA_INSTALL_DIR"
+fi
+[ -d "$install_dir" ] || fail "install destination '$install_dir' is not a directory"
+[ -w "$install_dir" ] ||
+    fail "install directory '$install_dir' is not writable; choose another with FABRICA_INSTALL_DIR (this installer never uses sudo)"
+
+final_path="$install_dir/fabrica"
+[ ! -d "$final_path" ] ||
+    fail "install destination '$final_path' is a directory or resolves to a directory; remove or rename it before installing"
+
+staged_file=$(mktemp "$install_dir/.fabrica.install.XXXXXX") ||
+    fail "could not create an exclusive staging file in '$install_dir'"
+cp "$binary" "$staged_file" ||
+    fail "could not stage Fabrica in '$install_dir'; check available space and permissions"
+chmod 0755 "$staged_file" || fail "could not set permissions on the staged Fabrica binary"
+mv -f "$staged_file" "$final_path" ||
+    fail "could not replace '$final_path' atomically"
+staged_file=
+
+printf 'Installed Fabrica %s to %s\n' "$version" "$final_path"
+case ":${PATH:-}:" in
+    *:"$install_dir":*) ;;
+    *) printf 'Add %s to PATH to run fabrica from your shell.\n' "$install_dir" ;;
+esac

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,262 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 OpenCHAMI Contributors
+#
+# SPDX-License-Identifier: MIT
+
+set -u
+
+script_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+installer="$script_dir/install.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/fabrica-install-tests.XXXXXX") || exit 1
+passed=0
+failed=0
+
+cleanup() {
+    rm -rf "$test_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+pass() {
+    passed=$((passed + 1))
+    printf 'ok - %s\n' "$1"
+}
+
+fail() {
+    failed=$((failed + 1))
+    printf 'not ok - %s: %s\n' "$1" "$2" >&2
+}
+
+make_case() {
+    case_name=$1
+    case_dir="$test_root/$case_name"
+    mock_bin="$case_dir/mock-bin"
+    fixture_dir="$case_dir/fixture"
+    install_dir="$case_dir/install"
+    case_tmp="$case_dir/tmp"
+    mkdir -p "$mock_bin" "$fixture_dir/archive" "$install_dir" "$case_tmp"
+
+    cat >"$fixture_dir/archive/fabrica" <<'EOF'
+#!/bin/sh
+printf 'mock fabrica\n'
+EOF
+    chmod 0755 "$fixture_dir/archive/fabrica"
+    tar -czf "$fixture_dir/fabrica.tar.gz" -C "$fixture_dir/archive" fabrica
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        fixture_checksum=$(sha256sum "$fixture_dir/fabrica.tar.gz" | awk '{print $1}')
+    else
+        fixture_checksum=$(shasum -a 256 "$fixture_dir/fabrica.tar.gz" | awk '{print $1}')
+    fi
+
+    cat >"$mock_bin/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+    -s) printf '%s\n' "$MOCK_OS" ;;
+    -m) printf '%s\n' "$MOCK_ARCH" ;;
+    *) exit 1 ;;
+esac
+EOF
+    chmod 0755 "$mock_bin/uname"
+
+    cat >"$mock_bin/curl" <<'EOF'
+#!/bin/sh
+output=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --output)
+            shift
+            output=$1
+            ;;
+        http://*|https://*) url=$1 ;;
+    esac
+    shift
+done
+[ -n "$output" ] && [ -n "$url" ] || exit 2
+printf '%s\n' "$url" >>"$MOCK_LOG"
+case "$url" in
+    */releases/latest)
+        printf '{"tag_name":"v9.8.7","prerelease":false}\n' >"$output"
+        ;;
+    */checksums.txt)
+        archive_name=$(cat "$MOCK_LAST_ARCHIVE")
+        if [ "${MOCK_BAD_CHECKSUM:-0}" = 1 ]; then
+            checksum=0000000000000000000000000000000000000000000000000000000000000000
+        else
+            checksum=$MOCK_CHECKSUM
+        fi
+        printf '%s  %s\n' "$checksum" "$archive_name" >"$output"
+        ;;
+    */fabrica_*.tar.gz)
+        archive_name=${url##*/}
+        printf '%s\n' "$archive_name" >"$MOCK_LAST_ARCHIVE"
+        cp "$MOCK_ARCHIVE" "$output"
+        ;;
+    *) exit 22 ;;
+esac
+EOF
+    chmod 0755 "$mock_bin/curl"
+}
+
+run_installer() {
+    MOCK_LOG="$case_dir/downloads.log" \
+    MOCK_LAST_ARCHIVE="$case_dir/archive-name" \
+    MOCK_ARCHIVE="$fixture_dir/fabrica.tar.gz" \
+    MOCK_CHECKSUM="$fixture_checksum" \
+    MOCK_OS=$1 \
+    MOCK_ARCH=$2 \
+    FABRICA_INSTALL_DIR=${FABRICA_INSTALL_DIR_OVERRIDE:-$install_dir} \
+    TMPDIR="$case_tmp" \
+    PATH="$mock_bin:$PATH" \
+    sh "$installer" >"$case_dir/stdout" 2>"$case_dir/stderr"
+}
+
+run_installer_with_predictable_symlink() {
+    MOCK_LOG="$case_dir/downloads.log" \
+    MOCK_LAST_ARCHIVE="$case_dir/archive-name" \
+    MOCK_ARCHIVE="$fixture_dir/fabrica.tar.gz" \
+    MOCK_CHECKSUM="$fixture_checksum" \
+    MOCK_OS=Linux \
+    MOCK_ARCH=x86_64 \
+    FABRICA_INSTALL_DIR="$install_dir" \
+    TMPDIR="$case_tmp" \
+    PATH="$mock_bin:$PATH" \
+    INSTALLER="$installer" \
+    SENTINEL="$case_dir/sentinel" \
+    PREDICTABLE_PATH="$case_dir/predictable-path" \
+    sh -c '
+        predictable="$FABRICA_INSTALL_DIR/.fabrica.install.$$"
+        printf "%s\n" "$predictable" >"$PREDICTABLE_PATH"
+        ln -s "$SENTINEL" "$predictable"
+        exec sh "$INSTALLER"
+    ' >"$case_dir/stdout" 2>"$case_dir/stderr"
+}
+
+make_case linux-x86-64
+if run_installer Linux amd64 && [ -x "$install_dir/fabrica" ] &&
+    grep -F '/fabrica_9.8.7_linux_x86_64.tar.gz' "$case_dir/downloads.log" >/dev/null; then
+    pass "Linux amd64 maps to linux x86_64"
+else
+    fail "Linux amd64 maps to linux x86_64" "installer failed or selected the wrong archive"
+fi
+
+make_case darwin-arm64
+if run_installer Darwin aarch64 && [ -x "$install_dir/fabrica" ] &&
+    grep -F '/fabrica_9.8.7_darwin_arm64.tar.gz' "$case_dir/downloads.log" >/dev/null; then
+    pass "Darwin aarch64 maps to darwin arm64"
+else
+    fail "Darwin aarch64 maps to darwin arm64" "installer failed or selected the wrong archive"
+fi
+
+make_case explicit-version
+if FABRICA_VERSION=v1.2.3 run_installer Linux x86_64 &&
+    grep -F '/releases/download/v1.2.3/fabrica_1.2.3_linux_x86_64.tar.gz' "$case_dir/downloads.log" >/dev/null &&
+    ! grep -F '/releases/latest' "$case_dir/downloads.log" >/dev/null; then
+    pass "FABRICA_VERSION accepts a leading v and skips discovery"
+else
+    fail "FABRICA_VERSION accepts a leading v and skips discovery" "explicit version was not used"
+fi
+unset FABRICA_VERSION
+
+make_case checksum-mismatch
+if MOCK_BAD_CHECKSUM=1 run_installer Linux x86_64; then
+    fail "checksum mismatch is rejected" "installer unexpectedly succeeded"
+elif [ ! -e "$install_dir/fabrica" ] && grep -F 'checksum verification failed' "$case_dir/stderr" >/dev/null; then
+    pass "checksum mismatch is rejected"
+else
+    fail "checksum mismatch is rejected" "expected checksum failure was not reported"
+fi
+unset MOCK_BAD_CHECKSUM
+
+make_case unsupported-platform
+if run_installer FreeBSD x86_64; then
+    fail "unsupported platforms are rejected" "installer unexpectedly succeeded"
+elif grep -F 'unsupported operating system' "$case_dir/stderr" >/dev/null; then
+    pass "unsupported platforms are rejected"
+else
+    fail "unsupported platforms are rejected" "expected platform error was not reported"
+fi
+
+make_case unwritable-destination
+blocked_path="$case_dir/blocked"
+printf 'not a directory\n' >"$blocked_path"
+FABRICA_INSTALL_DIR_OVERRIDE="$blocked_path/bin"
+if run_installer Linux x86_64; then
+    fail "unwritable destinations are rejected" "installer unexpectedly succeeded"
+elif grep -F 'choose a writable directory with FABRICA_INSTALL_DIR' "$case_dir/stderr" >/dev/null; then
+    pass "unwritable destinations are rejected"
+else
+    fail "unwritable destinations are rejected" "expected actionable destination error was not reported"
+fi
+unset FABRICA_INSTALL_DIR_OVERRIDE
+
+make_case final-destination-directory
+mkdir "$install_dir/fabrica"
+printf 'directory marker\n' >"$install_dir/fabrica/marker"
+if run_installer Linux x86_64; then
+    fail "final destination directories are rejected" "installer unexpectedly succeeded"
+elif grep -F 'is a directory or resolves to a directory' "$case_dir/stderr" >/dev/null &&
+    [ ! -e "$install_dir/fabrica/fabrica" ] &&
+    [ "$(cat "$install_dir/fabrica/marker")" = 'directory marker' ] &&
+    [ -z "$(find "$install_dir" -name '.fabrica.install.*' -print)" ]; then
+    pass "final destination directories are rejected without mutation"
+else
+    fail "final destination directories are rejected" "destination changed or staged content remained"
+fi
+
+make_case final-destination-symlink-directory
+symlink_target="$case_dir/symlink-target"
+mkdir "$symlink_target"
+printf 'symlink target marker\n' >"$symlink_target/marker"
+ln -s "$symlink_target" "$install_dir/fabrica"
+if run_installer Linux x86_64; then
+    fail "final destination symlinks to directories are rejected" "installer unexpectedly succeeded"
+else
+    final_listing=$(LC_ALL=C ls -ld "$install_dir/fabrica")
+    case "$final_listing" in
+        l*) final_is_symlink=true ;;
+        *) final_is_symlink=false ;;
+    esac
+    if grep -F 'is a directory or resolves to a directory' "$case_dir/stderr" >/dev/null &&
+        [ "$final_is_symlink" = true ] &&
+        [ ! -e "$symlink_target/fabrica" ] &&
+        [ "$(cat "$symlink_target/marker")" = 'symlink target marker' ] &&
+        [ -z "$(find "$install_dir" -name '.fabrica.install.*' -print)" ]; then
+        pass "final destination symlinks to directories are rejected without mutation"
+    else
+        fail "final destination symlinks to directories are rejected" "symlink target changed or staged content remained"
+    fi
+fi
+
+make_case predictable-staging-collision
+printf 'do not overwrite\n' >"$case_dir/sentinel"
+if run_installer_with_predictable_symlink; then
+    predictable_path=$(cat "$case_dir/predictable-path")
+    sentinel_contents=$(cat "$case_dir/sentinel")
+    predictable_listing=$(LC_ALL=C ls -ld "$predictable_path")
+    case "$predictable_listing" in
+        l*) predictable_is_symlink=true ;;
+        *) predictable_is_symlink=false ;;
+    esac
+    if [ "$sentinel_contents" = 'do not overwrite' ] &&
+        [ "$predictable_is_symlink" = true ] &&
+        [ -x "$install_dir/fabrica" ]; then
+        pass "predictable staging symlinks are not followed or overwritten"
+    else
+        fail "predictable staging symlinks are not followed or overwritten" "the pre-existing path or its target changed"
+    fi
+else
+    fail "predictable staging symlinks are not followed or overwritten" "installer failed with an unrelated error"
+fi
+
+make_case temporary-cleanup
+if MOCK_BAD_CHECKSUM=1 run_installer Linux x86_64; then
+    fail "temporary files are cleaned after failure" "installer unexpectedly succeeded"
+elif [ -z "$(find "$case_tmp" -name 'fabrica-install.*' -print)" ]; then
+    pass "temporary files are cleaned after failure"
+else
+    fail "temporary files are cleaned after failure" "temporary installer directory remains"
+fi
+
+printf '%s passed; %s failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
- Introduced a new POSIX installer script (`scripts/install.sh`) for easier installation on Linux and macOS.
- Added a test script (`scripts/test-install.sh`) to validate the installer functionality.
- Updated GitHub Actions workflow to include validation of the installer.
- Modified `.goreleaser.yaml` to include the installer as an extra file in the release.
- Enhanced README and documentation to reflect the new installation method and usage.
- Refactored version compatibility checks in the generate command to improve error handling.
- Added comprehensive tests for the new installer and version compatibility logic.

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [X] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
