### PR TITLE
test(codegen): cover the generic schema and the storage adapter

### DIFF
--- a/pkg/codegen/generated_schema_compile_test.go
+++ b/pkg/codegen/generated_schema_compile_test.go
@@ -1,0 +1,232 @@
+// Copyright © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openchami/fabrica/pkg/annotations"
+)
+
+// entVersion is the entgo.io/ent release the generated schemas are verified
+// against. Bump deliberately: a generated schema that compiles against one Ent
+// release is not guaranteed to compile against the next.
+const entVersion = "v0.14.6"
+
+// These tests answer a question the golden tests cannot: does the code we
+// generate actually build?
+//
+// Golden tests compare text. executeTemplate runs format.Source, which checks
+// syntax only — unused imports, missing imports and undefined identifiers all
+// pass gofmt. Every dedicated schema fabrica emitted before this file existed
+// was unbuildable, and nothing caught it, because no test ever handed the output
+// to a compiler.
+//
+// They shell out to `go build` in a temp module, so they need a Go toolchain and
+// entgo.io/ent resolvable (from the module cache or the network). Skipped in
+// -short mode.
+
+// newSchemaModule writes a throwaway module containing a schema package and
+// returns its directory. Files are given as name → content.
+func newSchemaModule(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping compile test in -short mode")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go toolchain available")
+	}
+
+	dir := t.TempDir()
+	schemaDir := filepath.Join(dir, "schema")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatalf("create schema dir: %v", err)
+	}
+
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(schemaDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	gomod := "module fabricaschematest\n\ngo 1.24\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	// Resolve dependencies. If this fails the environment cannot reach Ent, so
+	// skip rather than report a false failure.
+	for _, args := range [][]string{
+		{"get", "entgo.io/ent@" + entVersion},
+		{"get", "golang.org/x/crypto"},
+		{"mod", "tidy"},
+	} {
+		cmd := exec.Command("go", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("cannot resolve Ent dependencies (%v): %s", err, out)
+		}
+	}
+
+	return dir
+}
+
+// buildSchemaModule runs `go build` over the schema package and returns the
+// combined output plus whether it succeeded.
+func buildSchemaModule(t *testing.T, dir string) (string, bool) {
+	t.Helper()
+
+	cmd := exec.Command("go", "build", "./schema/")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err == nil
+}
+
+// TestGeneratedGoldenSchemasCompile builds every golden schema against a real
+// Ent release. This is the regression guard for the class of bug the goldens
+// missed entirely.
+func TestGeneratedGoldenSchemasCompile(t *testing.T) {
+	goldenDir := filepath.Join("testdata", "golden")
+
+	entries, err := os.ReadDir(goldenDir)
+	if err != nil {
+		t.Fatalf("read golden dir: %v", err)
+	}
+
+	files := make(map[string][]byte)
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".go.golden") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(goldenDir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		// Each golden declares a distinct type, so they coexist in one package.
+		files[strings.TrimSuffix(e.Name(), ".golden")] = content
+	}
+
+	if len(files) == 0 {
+		t.Fatal("no golden schemas found to compile")
+	}
+
+	dir := newSchemaModule(t, files)
+	if out, ok := buildSchemaModule(t, dir); !ok {
+		t.Errorf("generated golden schemas do not compile against entgo.io/ent %s:\n%s", entVersion, out)
+	}
+}
+
+// noStorageSpec has no hashed or encrypted field, so the generated schema must
+// NOT import dialect or bcrypt. This is the configuration that used to fail with
+// "imported and not used" — the common case, and the one both tokensmith
+// resources hit.
+type noStorageSpec struct {
+	Name      string    `json:"name" validate:"required"`
+	CreatedBy string    `json:"created_by"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type noStorageResource struct {
+	Spec noStorageSpec
+}
+
+// TestSchemaWithoutHashedFieldsCompiles pins the unused-import fix.
+func TestSchemaWithoutHashedFieldsCompiles(t *testing.T) {
+	annots := annotations.NewResourceAnnotations()
+	annots.IsResource = true
+	annots.StorageMode = annotations.StorageModeDedicated
+
+	name := annotations.NewFieldAnnotations("Name")
+	name.Size = 253
+	annots.Fields["Name"] = name
+
+	got := generateDedicatedSchema(t, &noStorageResource{}, "noStorageResource", annots)
+
+	for _, unwanted := range []string{`"entgo.io/ent/dialect"`, `"golang.org/x/crypto/bcrypt"`, `"context"`} {
+		if strings.Contains(string(got), unwanted) {
+			t.Errorf("schema with no hashed fields should not import %s:\n%s", unwanted, got)
+		}
+	}
+
+	dir := newSchemaModule(t, map[string][]byte{"nostorage.go": got})
+	if out, ok := buildSchemaModule(t, dir); !ok {
+		t.Errorf("schema without hashed fields does not compile:\n%s", out)
+	}
+}
+
+type sha256Spec struct {
+	Token string `json:"token" validate:"required"`
+}
+
+type sha256Resource struct {
+	Spec sha256Spec
+}
+
+// TestSchemaWithSHA256HashCompiles covers the other import branch: a hashed
+// field needs context, sha256 and hex, none of which were imported before.
+func TestSchemaWithSHA256HashCompiles(t *testing.T) {
+	annots := annotations.NewResourceAnnotations()
+	annots.IsResource = true
+	annots.StorageMode = annotations.StorageModeDedicated
+
+	token := annotations.NewFieldAnnotations("Token")
+	token.Storage = &annotations.StorageConfig{
+		Type: annotations.StorageTypeHashed,
+		Hash: &annotations.HashConfig{Algorithm: annotations.HashAlgorithmSHA256},
+	}
+	token.Sensitive = true
+	annots.Fields["Token"] = token
+
+	got := generateDedicatedSchema(t, &sha256Resource{}, "sha256Resource", annots)
+
+	for _, want := range []string{`"crypto/sha256"`, `"encoding/hex"`, `"context"`} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("sha256 schema is missing import %s:\n%s", want, got)
+		}
+	}
+	// bcrypt is not used by the sha256 path and must not be imported.
+	if strings.Contains(string(got), `"golang.org/x/crypto/bcrypt"`) {
+		t.Error("sha256 schema should not import bcrypt")
+	}
+
+	dir := newSchemaModule(t, map[string][]byte{"sha256.go": got})
+	if out, ok := buildSchemaModule(t, dir); !ok {
+		t.Errorf("sha256 schema does not compile:\n%s", out)
+	}
+}
+
+// TestHooksDoNotReferenceGeneratedPackage pins the layering fix. The hook used
+// to assert on *ent.<Name>Mutation, a type generated FROM the schema package, so
+// the schema could never compile. It now matches the mutation structurally.
+func TestHooksDoNotReferenceGeneratedPackage(t *testing.T) {
+	annots := annotations.NewResourceAnnotations()
+	annots.IsResource = true
+	annots.StorageMode = annotations.StorageModeDedicated
+
+	token := annotations.NewFieldAnnotations("Token")
+	token.Storage = &annotations.StorageConfig{
+		Type: annotations.StorageTypeHashed,
+		Hash: &annotations.HashConfig{Algorithm: annotations.HashAlgorithmBcrypt, Cost: 12},
+	}
+	annots.Fields["Token"] = token
+
+	got := string(generateDedicatedSchema(t, &sha256Resource{}, "sha256Resource", annots))
+
+	// Look for a real type assertion, not the explanatory comment that names
+	// the type it deliberately avoids.
+	if strings.Contains(got, "m.(*ent.") {
+		t.Error("hook asserts on the generated mutation type; the schema cannot compile against it")
+	}
+	if !strings.Contains(got, "m.(interface {") {
+		t.Errorf("hook should match the mutation structurally:\n%s", got)
+	}
+}

--- a/pkg/codegen/generated_schema_roundtrip_test.go
+++ b/pkg/codegen/generated_schema_roundtrip_test.go
@@ -1,0 +1,269 @@
+// Copyright © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openchami/fabrica/pkg/annotations"
+)
+
+// This test answers the last question the others cannot: does a schema fabrica
+// generates actually WORK?
+//
+// Compiling proves the file builds. It does not prove Ent accepts the schema,
+// that the columns and indexes can be created, or that a value written through
+// the generated client comes back as the same Go value. Those are separate
+// failure modes — a column typed as text will compile and migrate happily while
+// silently mangling every timestamp.
+//
+// The pipeline here is the real one:
+//
+//	fabrica generates schema  ->  entc generates a client  ->  migrate SQLite
+//	  ->  create a row  ->  read it back  ->  compare every field
+//
+// It is slow (Ent codegen plus two module builds) and needs entgo.io/ent,
+// ariga.io/atlas and a SQLite driver resolvable. Skipped in -short mode, and
+// skipped rather than failed when dependencies cannot be fetched.
+
+// RoundTripSpec exercises one field of every Go type the dedicated schema
+// template maps. The type name is exported deliberately: Ent's loader ignores
+// unexported schema types, so an unexported fixture silently produces
+// "no schema found".
+type RoundTripSpec struct {
+	Subject        string            `json:"subject" validate:"required"`
+	UsageCount     int               `json:"usage_count"`
+	Revoked        bool              `json:"revoked"`
+	SequenceNumber int64             `json:"sequence_number"`
+	Weight         float64           `json:"weight"`
+	TTL            time.Duration     `json:"ttl"`
+	IssuedAt       time.Time         `json:"issued_at" validate:"required"`
+	ConsumedAt     *time.Time        `json:"consumed_at"`
+	Scopes         []string          `json:"scopes"`
+	Fingerprint    []byte            `json:"fingerprint"`
+	ReplayAttempts []time.Time       `json:"replay_attempts"`
+	Labels         map[string]string `json:"labels"`
+}
+
+// RoundTrip is the resource under test.
+type RoundTrip struct {
+	Spec RoundTripSpec
+}
+
+// crudProgram writes a row through the generated client, reads it back, and
+// reports one line per field. Any mismatch exits non-zero.
+const crudProgram = `package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"roundtrip/ent"
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	db, err := sql.Open("sqlite", "file:ent?mode=memory&cache=shared&_fk=1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := ent.NewClient(ent.Driver(entsql.OpenDB(dialect.SQLite, db)))
+	defer client.Close()
+
+	ctx := context.Background()
+	if err := client.Schema.Create(ctx); err != nil {
+		log.Fatalf("MIGRATE FAILED: %v", err)
+	}
+	fmt.Println("migrate ok")
+
+	ttl := 90 * time.Minute
+	issued := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	created, err := client.RoundTrip.Create().
+		SetUID("uid-1").
+		SetName("row-1").
+		SetSubject("boot-service").
+		SetTTL(int64(ttl)).
+		SetIssuedAt(issued).
+		SetScopes([]string{"read", "write"}).
+		SetFingerprint([]byte{0xde, 0xad}).
+		SetReplayAttempts([]time.Time{issued}).
+		SetLabels(map[string]string{"env": "test"}).
+		SetSequenceNumber(42).
+		SetWeight(1.5).
+		SetUsageCount(3).
+		SetRevoked(false).
+		Save(ctx)
+	if err != nil {
+		log.Fatalf("CREATE FAILED: %v", err)
+	}
+
+	got, err := client.RoundTrip.Get(ctx, created.ID)
+	if err != nil {
+		log.Fatalf("READ FAILED: %v", err)
+	}
+
+	fail := 0
+	check := func(name string, ok bool, detail string) {
+		status := "ok"
+		if !ok {
+			status = "FAIL"
+			fail++
+		}
+		fmt.Printf("%s %s %s\n", status, name, detail)
+	}
+
+	check("time.Duration", time.Duration(got.TTL) == ttl, time.Duration(got.TTL).String())
+	check("time.Time", got.IssuedAt.UTC().Equal(issued), got.IssuedAt.UTC().String())
+	check("ptr-nil", got.ConsumedAt == nil, "nil")
+	check("[]string", len(got.Scopes) == 2 && got.Scopes[0] == "read", fmt.Sprint(got.Scopes))
+	check("[]byte", len(got.Fingerprint) == 2 && got.Fingerprint[0] == 0xde, fmt.Sprintf("%x", got.Fingerprint))
+	check("[]time.Time", len(got.ReplayAttempts) == 1, fmt.Sprint(len(got.ReplayAttempts)))
+	check("map", got.Labels["env"] == "test", fmt.Sprint(got.Labels))
+	check("int64", got.SequenceNumber == 42, fmt.Sprint(got.SequenceNumber))
+	check("float64", got.Weight == 1.5, fmt.Sprint(got.Weight))
+	check("int", got.UsageCount == 3, fmt.Sprint(got.UsageCount))
+	check("bool", !got.Revoked, fmt.Sprint(got.Revoked))
+
+	consumed := issued.Add(time.Minute)
+	upd, err := got.Update().SetConsumedAt(consumed).Save(ctx)
+	if err != nil {
+		log.Fatalf("UPDATE FAILED: %v", err)
+	}
+	check("ptr-set", upd.ConsumedAt != nil && upd.ConsumedAt.UTC().Equal(consumed), fmt.Sprint(upd.ConsumedAt))
+
+	if fail > 0 {
+		log.Fatalf("%d field(s) did not round-trip", fail)
+	}
+	fmt.Println("all round-trips ok")
+}
+`
+
+const entgenProgram = `package main
+
+import (
+	"log"
+
+	"entgo.io/ent/entc"
+	"entgo.io/ent/entc/gen"
+)
+
+func main() {
+	if err := entc.Generate("../../schema", &gen.Config{Target: "../../ent", Package: "roundtrip/ent"}); err != nil {
+		log.Fatalf("ent codegen: %v", err)
+	}
+}
+`
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// runIn executes a command in dir, returning combined output.
+func runIn(dir string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err
+}
+
+// TestGeneratedSchemaRoundTripsThroughEnt is the end-to-end proof.
+func TestGeneratedSchemaRoundTripsThroughEnt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end Ent round-trip in -short mode")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go toolchain available")
+	}
+
+	annots := annotations.NewResourceAnnotations()
+	annots.IsResource = true
+	annots.StorageMode = annotations.StorageModeDedicated
+
+	subject := annotations.NewFieldAnnotations("Subject")
+	subject.Size = 253
+	subject.NotNull = true
+	subject.Index = &annotations.IndexConfig{Type: annotations.IndexTypeBTree}
+	annots.Fields["Subject"] = subject
+
+	issued := annotations.NewFieldAnnotations("IssuedAt")
+	issued.Immutable = true
+	annots.Fields["IssuedAt"] = issued
+
+	annots.Indexes = []*annotations.CompositeIndex{
+		{Fields: []string{"Subject", "SequenceNumber"}, Name: "idx_subject_seq", Type: annotations.IndexTypeBTree},
+	}
+
+	if err := annotations.Validate(annots); err != nil {
+		t.Fatalf("fixture failed validation: %v", err)
+	}
+
+	schema := generateDedicatedSchema(t, &RoundTrip{}, "RoundTrip", annots)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "schema", "roundtrip.go"), string(schema))
+	writeFile(t, filepath.Join(dir, "cmd", "entgen", "main.go"), entgenProgram)
+	writeFile(t, filepath.Join(dir, "cmd", "crud", "main.go"), crudProgram)
+	writeFile(t, filepath.Join(dir, "go.mod"), "module roundtrip\n\ngo 1.24\n")
+
+	// Resolve dependencies; skip if the environment cannot.
+	for _, args := range [][]string{
+		{"get", "entgo.io/ent@" + entVersion},
+		{"get", "ariga.io/atlas"},
+		{"get", "golang.org/x/tools"},
+		{"get", "golang.org/x/crypto"},
+		{"get", "modernc.org/sqlite"},
+	} {
+		if out, err := runIn(dir, "go", args...); err != nil {
+			t.Skipf("cannot resolve dependencies for the round-trip test (%v): %s", err, out)
+		}
+	}
+	if out, err := runIn(dir, "go", "mod", "tidy"); err != nil {
+		t.Skipf("go mod tidy failed (%v): %s", err, out)
+	}
+
+	// Ent's own codegen must accept the schema. This catches semantic problems
+	// a compiler cannot see: unknown index fields, duplicate columns, field
+	// options Ent rejects.
+	if out, err := runIn(filepath.Join(dir, "cmd", "entgen"), "go", "run", "."); err != nil {
+		t.Fatalf("Ent rejected the generated schema:\n%s", out)
+	}
+
+	// Migrate and round-trip every field through a real database.
+	out, err := runIn(filepath.Join(dir, "cmd", "crud"), "go", "run", ".")
+	if err != nil {
+		t.Fatalf("round-trip failed:\n%s", out)
+	}
+
+	t.Logf("round-trip results:\n%s", out)
+
+	if !strings.Contains(out, "migrate ok") {
+		t.Error("migration did not report success")
+	}
+	if !strings.Contains(out, "all round-trips ok") {
+		t.Errorf("not every field round-tripped:\n%s", out)
+	}
+	if strings.Contains(out, "FAIL ") {
+		t.Errorf("a field did not round-trip:\n%s", out)
+	}
+}

--- a/pkg/codegen/generic_and_adapter_test.go
+++ b/pkg/codegen/generic_and_adapter_test.go
@@ -1,0 +1,350 @@
+// Copyright © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openchami/fabrica/pkg/codegen/testfixtures"
+)
+
+// Coverage for the two paths the dedicated-schema tests do not touch:
+//
+//   - the generic Ent schema trio (resource, label, annotation), which is what
+//     every service using storage=ent gets whether or not it declares
+//     annotations;
+//   - the storage adapter, queries and transactions, which are the code that
+//     actually moves data between Fabrica resources and Ent entities.
+//
+// The adapter is the more valuable of the two to cover: it imports the Ent
+// client that entc generates from our schemas, so nothing short of running the
+// whole chain can tell you it compiles.
+
+// fabricaRoot returns the repository root, so a generated module can replace
+// github.com/openchami/fabrica with the working tree under test.
+func fabricaRoot(t *testing.T) string {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve fabrica root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("expected fabrica go.mod at %s: %v", root, err)
+	}
+
+	return root
+}
+
+// generateProject runs the generator into a fresh directory and returns it.
+// withAdapter also emits the adapter, query helpers and storage layer.
+func generateProject(t *testing.T, modulePath string, withAdapter bool) string {
+	t.Helper()
+
+	projectDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	gen := NewGenerator(projectDir, "main", modulePath)
+	gen.StorageType = "ent"
+	gen.DBDriver = "postgres"
+
+	if err := gen.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+	if err := gen.RegisterResource(&testfixtures.Widget{}); err != nil {
+		t.Fatalf("RegisterResource: %v", err)
+	}
+	if err := gen.GenerateEntSchemas(); err != nil {
+		t.Fatalf("GenerateEntSchemas: %v", err)
+	}
+
+	if withAdapter {
+		if err := gen.GenerateEntAdapter(); err != nil {
+			t.Fatalf("GenerateEntAdapter: %v", err)
+		}
+		if err := gen.GenerateEntHelpers(); err != nil {
+			t.Fatalf("GenerateEntHelpers: %v", err)
+		}
+		if err := gen.GenerateStorage(); err != nil {
+			t.Fatalf("GenerateStorage: %v", err)
+		}
+	}
+
+	return projectDir
+}
+
+// prepareModule writes a go.mod for the generated project and resolves deps.
+// Skips the test when dependencies cannot be fetched.
+func prepareModule(t *testing.T, dir, modulePath string, needAtlas bool) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping generated-code compile test in -short mode")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go toolchain available")
+	}
+
+	gomod := "module " + modulePath + "\n\ngo 1.24\n\n" +
+		"require github.com/openchami/fabrica v0.4.9\n\n" +
+		"replace github.com/openchami/fabrica => " + fabricaRoot(t) + "\n"
+	writeFile(t, filepath.Join(dir, "go.mod"), gomod)
+
+	gets := [][]string{
+		{"get", "entgo.io/ent@" + entVersion},
+		{"get", "golang.org/x/crypto"},
+	}
+	if needAtlas {
+		gets = append(gets,
+			[]string{"get", "ariga.io/atlas"},
+			[]string{"get", "golang.org/x/tools"},
+			[]string{"get", "modernc.org/sqlite"},
+		)
+	}
+	for _, args := range gets {
+		if out, err := runIn(dir, "go", args...); err != nil {
+			t.Skipf("cannot resolve dependencies (%v): %s", err, out)
+		}
+	}
+	if out, err := runIn(dir, "go", "mod", "tidy"); err != nil {
+		t.Skipf("go mod tidy failed (%v): %s", err, out)
+	}
+}
+
+// runEntCodegen runs Ent's own generator over the project's schema package.
+func runEntCodegen(t *testing.T, dir, modulePath string) {
+	t.Helper()
+
+	prog := `package main
+
+import (
+	"log"
+
+	"entgo.io/ent/entc"
+	"entgo.io/ent/entc/gen"
+)
+
+func main() {
+	if err := entc.Generate("../../internal/storage/ent/schema",
+		&gen.Config{Target: "../../internal/storage/ent", Package: "` + modulePath + `/internal/storage/ent"}); err != nil {
+		log.Fatal(err)
+	}
+}
+`
+	writeFile(t, filepath.Join(dir, "cmd", "entgen", "main.go"), prog)
+
+	if out, err := runIn(dir, "go", "mod", "tidy"); err != nil {
+		t.Skipf("go mod tidy failed (%v): %s", err, out)
+	}
+	if out, err := runIn(filepath.Join(dir, "cmd", "entgen"), "go", "run", "."); err != nil {
+		t.Fatalf("Ent rejected the generated schemas:\n%s", out)
+	}
+}
+
+// TestGenericSchemasCompile builds the generic resource/label/annotation trio.
+// Every storage=ent project gets these, annotations or not.
+func TestGenericSchemasCompile(t *testing.T) {
+	const modulePath = "generictest"
+
+	dir := generateProject(t, modulePath, false)
+	prepareModule(t, dir, modulePath, false)
+
+	for _, name := range []string{"resource.go", "label.go", "annotation.go"} {
+		path := filepath.Join(dir, "internal", "storage", "ent", "schema", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected generic schema %s: %v", name, err)
+		}
+	}
+
+	if out, err := runIn(dir, "go", "build", "./internal/..."); err != nil {
+		t.Errorf("generic schemas do not compile:\n%s", out)
+	}
+}
+
+// genericCRUD exercises the generic resource table plus both edges.
+const genericCRUD = `package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"generictest/internal/storage/ent"
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	db, err := sql.Open("sqlite", "file:g?mode=memory&cache=shared&_fk=1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := ent.NewClient(ent.Driver(entsql.OpenDB(dialect.SQLite, db)))
+	defer client.Close()
+
+	ctx := context.Background()
+	if err := client.Schema.Create(ctx); err != nil {
+		log.Fatalf("MIGRATE FAILED: %v", err)
+	}
+	fmt.Println("migrate ok")
+
+	spec := json.RawMessage(` + "`" + `{"name":"widget-1","size":3}` + "`" + `)
+	status := json.RawMessage(` + "`" + `{"phase":"Ready"}` + "`" + `)
+
+	// Label and Annotation declare a required back-edge to Resource, so the
+	// resource has to exist first.
+	r, err := client.Resource.Create().
+		SetUID("uid-1").SetName("widget-1").SetAPIVersion("v1").SetKind("Widget").
+		SetResourceType("widgets").SetSpec(spec).SetStatus(status).
+		SetResourceVersion("1").SetNamespace("default").Save(ctx)
+	if err != nil {
+		log.Fatalf("CREATE FAILED: %v", err)
+	}
+	if _, err := client.Label.Create().SetKey("env").SetValue("test").SetResource(r).Save(ctx); err != nil {
+		log.Fatalf("LABEL FAILED: %v", err)
+	}
+	if _, err := client.Annotation.Create().SetKey("owner").SetValue("team-a").SetResource(r).Save(ctx); err != nil {
+		log.Fatalf("ANNOTATION FAILED: %v", err)
+	}
+
+	got, err := client.Resource.Get(ctx, r.ID)
+	if err != nil {
+		log.Fatalf("READ FAILED: %v", err)
+	}
+
+	fail := 0
+	check := func(n string, ok bool, d string) {
+		s := "ok"
+		if !ok {
+			s = "FAIL"
+			fail++
+		}
+		fmt.Printf("%s %s %s\n", s, n, d)
+	}
+
+	var backSpec map[string]interface{}
+	if err := json.Unmarshal(got.Spec, &backSpec); err != nil {
+		log.Fatalf("spec unmarshal: %v", err)
+	}
+	check("spec JSON", backSpec["name"] == "widget-1" && backSpec["size"].(float64) == 3, fmt.Sprint(backSpec))
+
+	var backStatus map[string]interface{}
+	if err := json.Unmarshal(got.Status, &backStatus); err != nil {
+		log.Fatalf("status unmarshal: %v", err)
+	}
+	check("status JSON", backStatus["phase"] == "Ready", fmt.Sprint(backStatus))
+
+	labels, err := got.QueryLabels().All(ctx)
+	if err != nil {
+		log.Fatalf("QUERY LABELS FAILED: %v", err)
+	}
+	check("labels edge", len(labels) == 1 && labels[0].Key == "env", fmt.Sprint(len(labels)))
+
+	anns, err := got.QueryAnnotations().All(ctx)
+	if err != nil {
+		log.Fatalf("QUERY ANNOTATIONS FAILED: %v", err)
+	}
+	check("annotations edge", len(anns) == 1 && anns[0].Key == "owner", fmt.Sprint(len(anns)))
+
+	if fail > 0 {
+		log.Fatalf("%d check(s) failed", fail)
+	}
+	fmt.Println("all round-trips ok")
+}
+`
+
+// TestGenericSchemaRoundTripsThroughEnt migrates the generic tables and proves
+// the JSON spec/status columns and both edges work against a real database.
+func TestGenericSchemaRoundTripsThroughEnt(t *testing.T) {
+	const modulePath = "generictest"
+
+	dir := generateProject(t, modulePath, false)
+	prepareModule(t, dir, modulePath, true)
+	runEntCodegen(t, dir, modulePath)
+
+	writeFile(t, filepath.Join(dir, "cmd", "crud", "main.go"), genericCRUD)
+	if out, err := runIn(dir, "go", "mod", "tidy"); err != nil {
+		t.Skipf("go mod tidy failed (%v): %s", err, out)
+	}
+
+	out, err := runIn(filepath.Join(dir, "cmd", "crud"), "go", "run", ".")
+	if err != nil {
+		t.Fatalf("generic round-trip failed:\n%s", out)
+	}
+
+	t.Logf("generic round-trip:\n%s", out)
+
+	if !strings.Contains(out, "migrate ok") {
+		t.Error("generic migration did not report success")
+	}
+	if !strings.Contains(out, "all round-trips ok") || strings.Contains(out, "FAIL ") {
+		t.Errorf("generic round-trip incomplete:\n%s", out)
+	}
+}
+
+// TestGeneratedStorageLayerCompiles is the adapter's coverage, and the widest
+// chain in the suite: fabrica generates schemas AND the adapter, entc generates
+// the Ent client from those schemas, and then the adapter is compiled against
+// that client. The adapter imports the generated package, so this is the only
+// way to know it builds.
+func TestGeneratedStorageLayerCompiles(t *testing.T) {
+	const modulePath = "adaptertest"
+
+	dir := generateProject(t, modulePath, true)
+	prepareModule(t, dir, modulePath, true)
+
+	for _, name := range []string{
+		"ent_adapter.go",
+		"ent_queries_generated.go",
+		"ent_transactions_generated.go",
+		"storage_generated.go",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, "internal", "storage", name)); err != nil {
+			t.Fatalf("expected generated %s: %v", name, err)
+		}
+	}
+
+	runEntCodegen(t, dir, modulePath)
+
+	if out, err := runIn(dir, "go", "build", "./internal/..."); err != nil {
+		t.Errorf("generated storage layer does not compile against the Ent client:\n%s", out)
+	}
+}
+
+// TestAdapterDoesNotImportPackageMain guards a sharp edge found while building
+// this coverage: the adapter imports the package each resource is declared in.
+// A resource declared in package main yields `main "main"`, which is never a
+// valid import. Real resources live in apis/<group>/<version>, so this only
+// bites in scratch programs — but the failure mode is baffling if you hit it.
+func TestAdapterDoesNotImportPackageMain(t *testing.T) {
+	dir := generateProject(t, "adaptertest", true)
+
+	content, err := os.ReadFile(filepath.Join(dir, "internal", "storage", "ent_adapter.go"))
+	if err != nil {
+		t.Fatalf("read adapter: %v", err)
+	}
+	if strings.Contains(string(content), `"main"`) {
+		t.Errorf("adapter imports package main, which cannot compile:\n%s", content)
+	}
+}

--- a/pkg/codegen/templates/ent/schema/resource_dedicated.go.tmpl
+++ b/pkg/codegen/templates/ent/schema/resource_dedicated.go.tmpl
@@ -3,16 +3,48 @@
 //
 // SPDX-License-Identifier: MIT
 
+{{- /*
+    Work out which imports this resource actually needs. Emitting the full set
+    unconditionally leaves unused imports on any resource without a hashed
+    field, which does not compile.
+*/ -}}
+{{- $hasHashed := false }}
+{{- $hasBcrypt := false }}
+{{- $hasSHA256 := false }}
+{{- range .SpecFields }}
+{{- $fa := index $.Annotations.Fields .Name }}
+{{- if and $fa $fa.Storage (eq $fa.Storage.Type "hashed") }}
+{{- $hasHashed = true }}
+{{- if $fa.Storage.Hash }}
+{{- if eq (printf "%s" $fa.Storage.Hash.Algorithm) "bcrypt" }}{{ $hasBcrypt = true }}{{ end }}
+{{- if eq (printf "%s" $fa.Storage.Hash.Algorithm) "sha256" }}{{ $hasSHA256 = true }}{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
 package schema
 
 import (
+	{{- if $hasHashed }}
+	"context"
+	{{- end }}
+	{{- if $hasSHA256 }}
+	"crypto/sha256"
+	"encoding/hex"
+	{{- end }}
+	{{- if $hasBcrypt }}
+	"fmt"
+	{{- end }}
 	"time"
 
 	"entgo.io/ent"
+	{{- if $hasHashed }}
 	"entgo.io/ent/dialect"
+	{{- end }}
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
+	{{- if $hasBcrypt }}
 	"golang.org/x/crypto/bcrypt"
+	{{- end }}
 )
 
 // {{.Name}} holds the schema definition for the {{.Name}} entity.
@@ -482,23 +514,30 @@ func ({{.Name}}) Hooks() []ent.Hook {
 		{{- range .SpecFields }}
 		{{- $fieldAnnots := index $.Annotations.Fields .Name }}
 		{{- if and $fieldAnnots $fieldAnnots.Storage (eq $fieldAnnots.Storage.Type "hashed") }}
-		// Hash {{.Name}} field with {{$fieldAnnots.Storage.Hash.Algorithm}} on create
+		// Hash {{.Name}} field with {{$fieldAnnots.Storage.Hash.Algorithm}} on create.
+		//
+		// The mutation is matched structurally rather than as *ent.{{$.Name}}Mutation:
+		// that type is generated FROM this package, so naming it here would be a
+		// circular reference. An anonymous interface gets the same typed access
+		// with no import of the generated package.
 		func(next ent.Mutator) ent.Mutator {
 			return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
 				if m.Op().Is(ent.OpCreate) {
-					if {{$.Name}}Mut, ok := m.(*ent.{{$.Name}}Mutation); ok {
-						if value, exists := {{$.Name}}Mut.{{.Name}}(); exists {
+					if mut, ok := m.(interface {
+						{{.Name}}() (string, bool)
+						Set{{.Name}}(string)
+					}); ok {
+						if value, exists := mut.{{.Name}}(); exists {
 							{{- if eq $fieldAnnots.Storage.Hash.Algorithm "bcrypt" }}
 							hashed, err := bcrypt.GenerateFromPassword([]byte(value), {{$fieldAnnots.Storage.Hash.Cost}})
 							if err != nil {
 								return nil, fmt.Errorf("hash {{.Name}}: %w", err)
 							}
-							{{$.Name}}Mut.Set{{.Name}}(string(hashed))
+							mut.Set{{.Name}}(string(hashed))
 							{{- else if eq $fieldAnnots.Storage.Hash.Algorithm "sha256" }}
 							hasher := sha256.New()
 							hasher.Write([]byte(value))
-							hashed := hex.EncodeToString(hasher.Sum(nil))
-							{{$.Name}}Mut.Set{{.Name}}(hashed)
+							mut.Set{{.Name}}(hex.EncodeToString(hasher.Sum(nil)))
 							{{- end }}
 						}
 					}

--- a/pkg/codegen/testdata/golden/token_dedicated_baseline.go.golden
+++ b/pkg/codegen/testdata/golden/token_dedicated_baseline.go.golden
@@ -2,10 +2,11 @@
 // Copyright © <year> OpenCHAMI a Series of LF Projects, LLC
 //
 // SPDX-License-Identifier: MIT
-
 package schema
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"entgo.io/ent"
@@ -98,17 +99,25 @@ func (baselineToken) Indexes() []ent.Index {
 // Hooks of the baselineToken.
 func (baselineToken) Hooks() []ent.Hook {
 	return []ent.Hook{
-		// Hash Value field with bcrypt on create
+		// Hash Value field with bcrypt on create.
+		//
+		// The mutation is matched structurally rather than as *ent.baselineTokenMutation:
+		// that type is generated FROM this package, so naming it here would be a
+		// circular reference. An anonymous interface gets the same typed access
+		// with no import of the generated package.
 		func(next ent.Mutator) ent.Mutator {
 			return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
 				if m.Op().Is(ent.OpCreate) {
-					if baselineTokenMut, ok := m.(*ent.baselineTokenMutation); ok {
-						if value, exists := baselineTokenMut.Value(); exists {
+					if mut, ok := m.(interface {
+						Value() (string, bool)
+						SetValue(string)
+					}); ok {
+						if value, exists := mut.Value(); exists {
 							hashed, err := bcrypt.GenerateFromPassword([]byte(value), 12)
 							if err != nil {
 								return nil, fmt.Errorf("hash Value: %w", err)
 							}
-							baselineTokenMut.SetValue(string(hashed))
+							mut.SetValue(string(hashed))
 						}
 					}
 				}

--- a/pkg/codegen/testdata/golden/token_dedicated_full.go.golden
+++ b/pkg/codegen/testdata/golden/token_dedicated_full.go.golden
@@ -2,10 +2,11 @@
 // Copyright © <year> OpenCHAMI a Series of LF Projects, LLC
 //
 // SPDX-License-Identifier: MIT
-
 package schema
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"entgo.io/ent"
@@ -152,17 +153,25 @@ func (goldenToken) Indexes() []ent.Index {
 // Hooks of the goldenToken.
 func (goldenToken) Hooks() []ent.Hook {
 	return []ent.Hook{
-		// Hash Value field with bcrypt on create
+		// Hash Value field with bcrypt on create.
+		//
+		// The mutation is matched structurally rather than as *ent.goldenTokenMutation:
+		// that type is generated FROM this package, so naming it here would be a
+		// circular reference. An anonymous interface gets the same typed access
+		// with no import of the generated package.
 		func(next ent.Mutator) ent.Mutator {
 			return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
 				if m.Op().Is(ent.OpCreate) {
-					if goldenTokenMut, ok := m.(*ent.goldenTokenMutation); ok {
-						if value, exists := goldenTokenMut.Value(); exists {
+					if mut, ok := m.(interface {
+						Value() (string, bool)
+						SetValue(string)
+					}); ok {
+						if value, exists := mut.Value(); exists {
 							hashed, err := bcrypt.GenerateFromPassword([]byte(value), 12)
 							if err != nil {
 								return nil, fmt.Errorf("hash Value: %w", err)
 							}
-							goldenTokenMut.SetValue(string(hashed))
+							mut.SetValue(string(hashed))
 						}
 					}
 				}

--- a/pkg/codegen/testdata/golden/token_dedicated_types.go.golden
+++ b/pkg/codegen/testdata/golden/token_dedicated_types.go.golden
@@ -2,17 +2,14 @@
 // Copyright © <year> OpenCHAMI a Series of LF Projects, LLC
 //
 // SPDX-License-Identifier: MIT
-
 package schema
 
 import (
 	"time"
 
 	"entgo.io/ent"
-	"entgo.io/ent/dialect"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // typedToken holds the schema definition for the typedToken entity.

--- a/pkg/codegen/testfixtures/fixtures.go
+++ b/pkg/codegen/testfixtures/fixtures.go
@@ -1,0 +1,42 @@
+// Copyright © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+// Package testfixtures holds resource types used to verify code generation.
+//
+// These deliberately live in a normal (non-test) package rather than in a
+// _test.go file. The generated storage adapter imports the package each
+// resource is declared in, and that import has to resolve from a *separate*
+// module — the throwaway project the tests generate into. A type declared in a
+// _test.go file exists only inside fabrica's own test binary, so the generated
+// adapter would reference an identifier that is not there.
+//
+// Nothing here is part of fabrica's supported API. It exists so the adapter,
+// query and storage templates can be compiled against a real Ent client.
+package testfixtures
+
+import "github.com/openchami/fabrica/pkg/resource"
+
+// WidgetSpec is the desired state of a Widget.
+type WidgetSpec struct {
+	Name string `json:"name"`
+	Size int    `json:"size"`
+}
+
+// WidgetStatus is the observed state of a Widget.
+type WidgetStatus struct {
+	Phase string `json:"phase,omitempty"`
+}
+
+// Widget models a resource the way a real service does: embedding
+// resource.Resource, which supplies APIVersion, Kind and Metadata.
+//
+// The generated adapter expects that embedded type in non-versioned mode. A
+// resource declaring those fields directly, without the embed, produces an
+// adapter that references fields the resource does not have — which compiles
+// in fabrica and fails only in the generated project.
+type Widget struct {
+	resource.Resource
+	Spec   WidgetSpec   `json:"spec"`
+	Status WidgetStatus `json:"status,omitempty"`
+}


### PR DESCRIPTION
**Stack** (bottom → top, merge in this order):
1. #90 `fabrica/annotation-vocabulary` → `main`
2. #91 `fabrica/pluggable-generators`
3. #92 `fabrica/annotation-parse-fixes`
4. #93 `fabrica/schema-type-mapping`
5. #94 `fabrica/generated-schema-compiles`
6. #95 `fabrica/generic-and-adapter-coverage` 👈
7. #96 `fabrica/hashing-hook-coverage`

---

Based on `fabrica/generated-schema-compiles`.

**Commits in this PR:**
- test(codegen): cover the generic schema and the storage adapter

<sub>Stacked PRs created manually with `gh` — merge bottom-up; GitHub retargets children automatically.</sub>