### PR TITLE
fix(client): redact authorization tokens in debug logs

### DIFF
--- a/cmd/fabrica/client_auth_template_test.go
+++ b/cmd/fabrica/client_auth_template_test.go
@@ -26,6 +26,51 @@ func TestTemplate_ClientLibrary_BearerTokenSupport(t *testing.T) {
 	}
 }
 
+func TestTemplate_ClientLibrary_RedactsAuthorizationInDebugLogs(t *testing.T) {
+	clientTmpl := mustReadFile(t, "pkg/codegen/templates/client/client.go.tmpl")
+
+	checks := []struct {
+		content string
+		msg     string
+	}{
+		{"showToken  bool", "per-client token visibility state"},
+		{"const tokenPrefixLen = 6", "token prefix length"},
+		{"func RedactToken(token string, show bool) string", "token redaction helper with explicit visibility state"},
+		{"func redactAuthHeaderValues(vals []string, show bool) []string", "Authorization value redaction helper with explicit visibility state"},
+		{"func isAuthorizationHeader(key string) bool", "Authorization header detector"},
+		{"http.CanonicalHeaderKey(key) == \"Authorization\"", "case-insensitive Authorization header comparison"},
+		{"c.logger.Debug().Msgf(\"  %s: %s\", k, redactAuthHeaderValues(v, c.showToken))", "redacted Authorization header logging using per-client state"},
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(clientTmpl, check.content) {
+			t.Errorf("client template must contain %s", check.msg)
+		}
+	}
+
+	if strings.Contains(clientTmpl, "var ShowToken bool") {
+		t.Error("client template must not use package-global token visibility state")
+	}
+
+	if got := strings.Count(clientTmpl, "c.logger.Debug().Msgf(\"  %s: %s\", k, redactAuthHeaderValues(v, c.showToken))"); got != 2 {
+		t.Errorf("client template must redact Authorization values in request and response logs; got %d occurrences", got)
+	}
+}
+
+func TestTemplate_ClientLibrary_ShowTokenChaining(t *testing.T) {
+	clientTmpl := mustReadFile(t, "pkg/codegen/templates/client/client.go.tmpl")
+
+	if !strings.Contains(clientTmpl, "func (c *Client) WithShowToken(show bool) *Client") {
+		t.Fatal("client template must provide WithShowToken")
+	}
+	if !strings.Contains(clientTmpl, "showToken:   show,") {
+		t.Fatal("WithShowToken must set token visibility on the returned client")
+	}
+	if got := strings.Count(clientTmpl, "showToken:   c.showToken,"); got != 2 {
+		t.Errorf("WithVersion and WithBearerToken must preserve token visibility; got %d copies", got)
+	}
+}
+
 func TestTemplate_ClientCLI_BearerTokenFlagSupport(t *testing.T) {
 	cliTmpl := mustReadFile(t, "pkg/codegen/templates/client/cmd.go.tmpl")
 
@@ -43,6 +88,26 @@ func TestTemplate_ClientCLI_BearerTokenFlagSupport(t *testing.T) {
 	}
 	if !strings.Contains(cliTmpl, "c = c.WithBearerToken(token)") {
 		t.Fatalf("cli template must configure client with bearer token")
+	}
+}
+
+func TestTemplate_ClientCLI_ShowTokenFlagSupport(t *testing.T) {
+	cliTmpl := mustReadFile(t, "pkg/codegen/templates/client/cmd.go.tmpl")
+
+	checks := []struct {
+		content string
+		msg     string
+	}{
+		{"--show-token   Show the full bearer token in debug logs", "document --show-token"},
+		{"BoolVar(&showToken, \"show-token\", false", "register --show-token as disabled by default"},
+		{"BindPFlag(\"show-token\"", "bind --show-token to configuration"},
+		{"c = c.WithShowToken(viper.GetBool(\"show-token\"))", "apply --show-token to the client instance"},
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(cliTmpl, check.content) {
+			t.Errorf("client CLI template must %s", check.msg)
+		}
 	}
 }
 

--- a/pkg/codegen/generator_test.go
+++ b/pkg/codegen/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -48,6 +49,52 @@ func TestGlobalAndMiddlewareTemplateDataIncludeCopyrightYear(t *testing.T) {
 		if got, ok := data["CopyrightYear"].(int); !ok || got != time.Now().UTC().Year() {
 			t.Fatalf("%s CopyrightYear = %v, want %d", name, data["CopyrightYear"], time.Now().UTC().Year())
 		}
+	}
+}
+
+func TestGenerateClientUsesPerClientTokenVisibility(t *testing.T) {
+	outDir := t.TempDir()
+	gen := NewGenerator(outDir, "client", "example.com/test")
+	gen.Resources = []ResourceMetadata{
+		{
+			Name:         "Node",
+			PluralName:   "nodes",
+			Package:      "example.com/test/apis/v1",
+			PackageAlias: "v1",
+			TypeName:     "*v1.Node",
+			SpecType:     "v1.NodeSpec",
+			StatusType:   "v1.NodeStatus",
+			URLPath:      "/nodes",
+			StorageName:  "Node",
+		},
+	}
+
+	if err := gen.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+	if err := gen.GenerateClient(); err != nil {
+		t.Fatalf("GenerateClient: %v", err)
+	}
+
+	generated, err := os.ReadFile(filepath.Join(outDir, "client_generated.go"))
+	if err != nil {
+		t.Fatalf("read generated client: %v", err)
+	}
+	client := string(generated)
+
+	if !regexp.MustCompile(`showToken\s+bool\s+// Whether access tokens`).MatchString(client) {
+		t.Error("generated client missing per-client token visibility field")
+	}
+	for _, want := range []string{
+		"func (c *Client) WithShowToken(show bool) *Client",
+		"redactAuthHeaderValues(v, c.showToken)",
+	} {
+		if !strings.Contains(client, want) {
+			t.Errorf("generated client missing %q", want)
+		}
+	}
+	if strings.Contains(client, "var ShowToken bool") {
+		t.Error("generated client contains package-global token visibility state")
 	}
 }
 

--- a/pkg/codegen/templates/client/client.go.tmpl
+++ b/pkg/codegen/templates/client/client.go.tmpl
@@ -66,6 +66,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 {{if $hasVersioning}}	"time"{{end}}
 
 	"github.com/openchami/fabrica/pkg/fabrica"
@@ -80,11 +81,52 @@ import (
 
 // Client provides access to the inventory API
 type Client struct {
-	baseURL    *url.URL
-	httpClient *http.Client
-	logger     zerolog.Logger
-	version    string // Optional API version for Accept/Content-Type headers
+	baseURL     *url.URL
+	httpClient  *http.Client
+	logger      zerolog.Logger
+	version     string // Optional API version for Accept/Content-Type headers
 	bearerToken string // Optional JWT bearer token for Authorization header
+	showToken   bool   // Whether access tokens are shown in full in debug logs
+}
+
+// tokenPrefixLen is the number of leading characters of a token to keep when
+// truncating it for logs.
+const tokenPrefixLen = 6
+
+// RedactToken returns token unchanged if show is true. Otherwise, it
+// returns a truncated form of the token that still indicates a token exists.
+// Tokens that are tokenPrefixLen characters or shorter are fully masked.
+func RedactToken(token string, show bool) string {
+	if show || token == "" {
+		return token
+	}
+	if len(token) <= tokenPrefixLen {
+		return "..."
+	}
+	return token[:tokenPrefixLen] + "..."
+}
+
+// redactAuthHeaderValues returns a copy of Authorization header values with
+// their token portions redacted unless show is true.
+func redactAuthHeaderValues(vals []string, show bool) []string {
+	if show {
+		return vals
+	}
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		const bearerPrefix = "Bearer "
+		if strings.HasPrefix(v, bearerPrefix) {
+			out[i] = bearerPrefix + RedactToken(strings.TrimPrefix(v, bearerPrefix), show)
+		} else {
+			out[i] = RedactToken(v, show)
+		}
+	}
+	return out
+}
+
+// isAuthorizationHeader reports whether key is the Authorization header.
+func isAuthorizationHeader(key string) bool {
+	return http.CanonicalHeaderKey(key) == "Authorization"
 }
 
 // ErrorResponse represents an API error response
@@ -130,6 +172,7 @@ func (c *Client) WithVersion(version string) *Client {
 		httpClient:  c.httpClient,
 		version:     version,
 		bearerToken: c.bearerToken,
+		showToken:   c.showToken,
 		logger:      c.logger,
 	}
 }
@@ -141,6 +184,20 @@ func (c *Client) WithBearerToken(token string) *Client {
 		httpClient:  c.httpClient,
 		version:     c.version,
 		bearerToken: token,
+		showToken:   c.showToken,
+		logger:      c.logger,
+	}
+}
+
+// WithShowToken returns a new client configured to show full access tokens in
+// debug logs when show is true. Tokens are truncated by default.
+func (c *Client) WithShowToken(show bool) *Client {
+	return &Client{
+		baseURL:     c.baseURL,
+		httpClient:  c.httpClient,
+		version:     c.version,
+		bearerToken: c.bearerToken,
+		showToken:   show,
 		logger:      c.logger,
 	}
 }
@@ -185,7 +242,11 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body in
 	if len(req.Header) > 0 {
 		c.logger.Debug().Msg("Request headers:")
 		for k, v := range req.Header {
-			c.logger.Debug().Msgf("  %s: %s", k, v)
+			if isAuthorizationHeader(k) {
+				c.logger.Debug().Msgf("  %s: %s", k, redactAuthHeaderValues(v, c.showToken))
+			} else {
+				c.logger.Debug().Msgf("  %s: %s", k, v)
+			}
 		}
 	} else {
 		c.logger.Debug().Msg("No headers in request")
@@ -216,7 +277,11 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body in
 		if len(resp.Header) > 0 {
 			c.logger.Debug().Msg("Response headers:")
 			for k, v := range resp.Header {
-				c.logger.Debug().Msgf("  %s: %s", k, v)
+				if isAuthorizationHeader(k) {
+					c.logger.Debug().Msgf("  %s: %s", k, redactAuthHeaderValues(v, c.showToken))
+				} else {
+					c.logger.Debug().Msgf("  %s: %s", k, v)
+				}
 			}
 		} else {
 			c.logger.Debug().Msg("No headers in response")

--- a/pkg/codegen/templates/client/cmd.go.tmpl
+++ b/pkg/codegen/templates/client/cmd.go.tmpl
@@ -21,6 +21,7 @@
 //   --output, -o   Output format: table, json, yaml (env: {{toUpper .ProjectName}}_OUTPUT)
 //   --version, -v  API version to request: v1, v2beta1, etc. (env: {{toUpper .ProjectName}}_VERSION)
 //   --token        JWT bearer token (env: {{toUpper .ProjectName}}_TOKEN)
+//   --show-token   Show the full bearer token in debug logs
 //   --config       Config file path (default: ~/.{{.ProjectName}}-cli.yaml)
 //
 // Configuration sources (in order of precedence):
@@ -89,6 +90,7 @@ var (
 	output      string
 	apiVersion  string
 	bearerToken string
+	showToken   bool
 	logLevel    client.LogLevel
 )
 
@@ -115,6 +117,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "table", "output format: table, json, yaml")
 	rootCmd.PersistentFlags().StringVarP(&apiVersion, "version", "v", "", "API version to request (e.g., v1, v2beta1)")
 	rootCmd.PersistentFlags().StringVar(&bearerToken, "token", "", "JWT bearer token")
+	rootCmd.PersistentFlags().BoolVar(&showToken, "show-token", false, "show full bearer token in debug logs instead of a truncated value")
 	rootCmd.PersistentFlags().VarP(&logLevel, "log-level", "l", "set verbosity of logs (e.g., info, warning, debug)")
 
 	// Register shell completion functions
@@ -126,6 +129,7 @@ func init() {
 	viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 	viper.BindPFlag("version", rootCmd.PersistentFlags().Lookup("version"))
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
+	viper.BindPFlag("show-token", rootCmd.PersistentFlags().Lookup("show-token"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
 
 	// Environment variable support
@@ -167,6 +171,7 @@ func getClient() (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	c = c.WithShowToken(viper.GetBool("show-token"))
 
 	// Apply version if specified
 	version := viper.GetString("version")


### PR DESCRIPTION
### Description

Hide bearer tokens by default in generated client request and response logs, while allowing explicit disclosure through `--show-token`. Introduce `client.WithShowToken(bool)` to toggle token redaction from the client library.

Store token visibility per client instead of globally to avoid races between concurrent clients, and preserve the setting across chained client options.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
